### PR TITLE
Refactor layered dependencies to keep Tauri isolated from repository layer

### DIFF
--- a/crates/sql-intelliscan-services/src/lib.rs
+++ b/crates/sql-intelliscan-services/src/lib.rs
@@ -1,3 +1,3 @@
 mod services;
 
-pub use services::GreetingService;
+pub use services::{greet, GreetingService};

--- a/crates/sql-intelliscan-services/src/services.rs
+++ b/crates/sql-intelliscan-services/src/services.rs
@@ -1,4 +1,5 @@
 use sql_intelliscan_repository::BackendMetadataRepository;
+use sql_intelliscan_repository::StaticBackendMetadataRepository;
 
 #[derive(Debug, Clone, Copy)]
 pub struct GreetingService<R> {
@@ -20,4 +21,8 @@ where
             self.repository.origin()
         )
     }
+}
+
+pub fn greet(name: &str) -> String {
+    GreetingService::new(StaticBackendMetadataRepository).greet(name)
 }

--- a/crates/sql-intelliscan-services/tests/services.rs
+++ b/crates/sql-intelliscan-services/tests/services.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use sql_intelliscan_repository::BackendMetadataRepository;
-use sql_intelliscan_services::GreetingService;
+use sql_intelliscan_services::{greet, GreetingService};
 
 struct TestBackendMetadataRepository;
 
@@ -18,5 +18,13 @@ fn GivenRepositoryDouble_WhenGreetingIsRequested_ThenService_ShouldUseRepository
     assert_eq!(
         service.greet("Carlos"),
         "Hello, Carlos! You've been greeted from TestBackend!"
+    );
+}
+
+#[test]
+fn GivenDefaultServiceFacade_WhenGreetingIsRequested_ThenIt_ShouldResolveRepositoryInternally() {
+    assert_eq!(
+        greet("Carlos"),
+        "Hello, Carlos! You've been greeted from Rust!"
     );
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,5 +22,4 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sql-intelliscan-repository = { path = "../crates/sql-intelliscan-repository" }
 sql-intelliscan-services = { path = "../crates/sql-intelliscan-services" }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,6 @@
 use std::sync::{Mutex, OnceLock};
 
-use sql_intelliscan_repository::StaticBackendMetadataRepository;
-use sql_intelliscan_services::GreetingService;
+use sql_intelliscan_services::greet as greet_from_services;
 
 type BuilderFactory = fn() -> tauri::Builder<tauri::Wry>;
 type Runner = fn(tauri::Builder<tauri::Wry>);
@@ -24,7 +23,7 @@ fn backend_runner() -> &'static Mutex<BackendRunner> {
 }
 
 pub fn greet(name: &str) -> String {
-    GreetingService::new(StaticBackendMetadataRepository).greet(name)
+    greet_from_services(name)
 }
 
 #[tauri::command]


### PR DESCRIPTION
### Motivation
- Enforce the layered architecture from issue `#4` so the UI/Tauri layer depends only on Services and not directly on Repository or data-access layers.
- Move repository construction responsibility out of the UI to keep dependencies minimal and maintainable.

### Description
- Removed the direct `sql-intelliscan-repository` dependency from `src-tauri/Cargo.toml` so Tauri no longer references the repository crate.
- Added a service-level facade `greet(name: &str)` in `crates/sql-intelliscan-services/src/services.rs` that constructs `StaticBackendMetadataRepository` internally and delegates to `GreetingService`.
- Exported the new facade from `crates/sql-intelliscan-services/src/lib.rs` and updated `src-tauri/src/lib.rs` to call `sql_intelliscan_services::greet` instead of instantiating the repository in UI code.
- Added an integration-style test in `crates/sql-intelliscan-services/tests/services.rs` to validate the default facade wiring alongside the existing unit test that uses a repo double.

### Testing
- Ran `cargo test -p sql-intelliscan-services -p sql-intelliscan-repository -p sql-intelliscan-common` and the crate-layer tests completed successfully.
- Ran `cargo test -p sql-intelliscan-services -p sql-intelliscan` and the services tests plus Tauri backend contract tests completed successfully.
- Verified dependency graph with `cargo tree -p sql-intelliscan --depth 2` to confirm `src-tauri` depends on `sql-intelliscan-services` (repository is only transitively available through services).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2a31508c83208a33ee0821bd7d86)