### PR TITLE
Implement constructor-injected application services in services crate

### DIFF
--- a/crates/sql-intelliscan-services/src/contracts/audit_repository_contract.rs
+++ b/crates/sql-intelliscan-services/src/contracts/audit_repository_contract.rs
@@ -1,0 +1,3 @@
+pub trait AuditRepository {
+    fn save_entry(&self, entry: &str);
+}

--- a/crates/sql-intelliscan-services/src/contracts/configuration_repository_contract.rs
+++ b/crates/sql-intelliscan-services/src/contracts/configuration_repository_contract.rs
@@ -1,0 +1,3 @@
+pub trait ConfigurationRepository {
+    fn find_value(&self, key: &str) -> Option<String>;
+}

--- a/crates/sql-intelliscan-services/src/contracts/connection_repository_contract.rs
+++ b/crates/sql-intelliscan-services/src/contracts/connection_repository_contract.rs
@@ -1,0 +1,3 @@
+pub trait ConnectionRepository {
+    fn can_connect(&self, connection_id: &str) -> bool;
+}

--- a/crates/sql-intelliscan-services/src/contracts/mod.rs
+++ b/crates/sql-intelliscan-services/src/contracts/mod.rs
@@ -1,3 +1,9 @@
+mod audit_repository_contract;
 mod backend_metadata_repository_contract;
+mod configuration_repository_contract;
+mod connection_repository_contract;
 
+pub use audit_repository_contract::AuditRepository;
 pub use backend_metadata_repository_contract::BackendMetadataRepository;
+pub use configuration_repository_contract::ConfigurationRepository;
+pub use connection_repository_contract::ConnectionRepository;

--- a/crates/sql-intelliscan-services/src/lib.rs
+++ b/crates/sql-intelliscan-services/src/lib.rs
@@ -3,4 +3,4 @@ pub mod errors;
 pub mod models;
 pub mod use_cases;
 
-pub use use_cases::{greet, GreetingService};
+pub use use_cases::{AuditService, ConfigurationService, ConnectionService, GreetingService};

--- a/crates/sql-intelliscan-services/src/use_cases/audit_use_case.rs
+++ b/crates/sql-intelliscan-services/src/use_cases/audit_use_case.rs
@@ -1,0 +1,19 @@
+use crate::contracts::AuditRepository;
+
+#[derive(Debug, Clone)]
+pub struct AuditService<R> {
+    repository: R,
+}
+
+impl<R> AuditService<R>
+where
+    R: AuditRepository,
+{
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    pub fn register_audit_entry(&self, entry: &str) {
+        self.repository.save_entry(entry);
+    }
+}

--- a/crates/sql-intelliscan-services/src/use_cases/configuration_use_case.rs
+++ b/crates/sql-intelliscan-services/src/use_cases/configuration_use_case.rs
@@ -1,0 +1,19 @@
+use crate::contracts::ConfigurationRepository;
+
+#[derive(Debug, Clone)]
+pub struct ConfigurationService<R> {
+    repository: R,
+}
+
+impl<R> ConfigurationService<R>
+where
+    R: ConfigurationRepository,
+{
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    pub fn get_configuration_value(&self, key: &str) -> Option<String> {
+        self.repository.find_value(key)
+    }
+}

--- a/crates/sql-intelliscan-services/src/use_cases/connection_use_case.rs
+++ b/crates/sql-intelliscan-services/src/use_cases/connection_use_case.rs
@@ -1,0 +1,19 @@
+use crate::contracts::ConnectionRepository;
+
+#[derive(Debug, Clone)]
+pub struct ConnectionService<R> {
+    repository: R,
+}
+
+impl<R> ConnectionService<R>
+where
+    R: ConnectionRepository,
+{
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    pub fn validate_connection(&self, connection_id: &str) -> bool {
+        self.repository.can_connect(connection_id)
+    }
+}

--- a/crates/sql-intelliscan-services/src/use_cases/greet_use_case.rs
+++ b/crates/sql-intelliscan-services/src/use_cases/greet_use_case.rs
@@ -1,5 +1,3 @@
-use sql_intelliscan_repository::StaticBackendMetadataRepository;
-
 use crate::contracts::BackendMetadataRepository;
 
 #[derive(Debug, Clone, Copy)]
@@ -22,8 +20,4 @@ where
             self.repository.origin()
         )
     }
-}
-
-pub fn greet(name: &str) -> String {
-    GreetingService::new(StaticBackendMetadataRepository).greet(name)
 }

--- a/crates/sql-intelliscan-services/src/use_cases/mod.rs
+++ b/crates/sql-intelliscan-services/src/use_cases/mod.rs
@@ -1,3 +1,9 @@
+mod audit_use_case;
+mod configuration_use_case;
+mod connection_use_case;
 mod greet_use_case;
 
-pub use greet_use_case::{greet, GreetingService};
+pub use audit_use_case::AuditService;
+pub use configuration_use_case::ConfigurationService;
+pub use connection_use_case::ConnectionService;
+pub use greet_use_case::GreetingService;

--- a/crates/sql-intelliscan-services/tests/services.rs
+++ b/crates/sql-intelliscan-services/tests/services.rs
@@ -1,13 +1,50 @@
 #![allow(non_snake_case)]
 
-use sql_intelliscan_repository::BackendMetadataRepository;
-use sql_intelliscan_services::{greet, GreetingService};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use sql_intelliscan_services::{
+    contracts::{
+        AuditRepository, BackendMetadataRepository, ConfigurationRepository, ConnectionRepository,
+    },
+    AuditService, ConfigurationService, ConnectionService, GreetingService,
+};
 
 struct TestBackendMetadataRepository;
 
 impl BackendMetadataRepository for TestBackendMetadataRepository {
     fn origin(&self) -> &'static str {
         "TestBackend"
+    }
+}
+
+struct TestConnectionRepository;
+
+impl ConnectionRepository for TestConnectionRepository {
+    fn can_connect(&self, connection_id: &str) -> bool {
+        connection_id == "valid-connection"
+    }
+}
+
+#[derive(Clone)]
+struct TestAuditRepository {
+    entries: Rc<RefCell<Vec<String>>>,
+}
+
+impl AuditRepository for TestAuditRepository {
+    fn save_entry(&self, entry: &str) {
+        self.entries.borrow_mut().push(entry.to_owned());
+    }
+}
+
+struct TestConfigurationRepository;
+
+impl ConfigurationRepository for TestConfigurationRepository {
+    fn find_value(&self, key: &str) -> Option<String> {
+        match key {
+            "theme" => Some("dark".to_owned()),
+            _ => None,
+        }
     }
 }
 
@@ -22,9 +59,35 @@ fn GivenRepositoryDouble_WhenGreetingIsRequested_ThenService_ShouldUseRepository
 }
 
 #[test]
-fn GivenDefaultServiceFacade_WhenGreetingIsRequested_ThenIt_ShouldResolveRepositoryInternally() {
+fn GivenConnectionRepository_WhenValidationIsRequested_ThenService_ShouldDelegateConnectivityCheck()
+{
+    let service = ConnectionService::new(TestConnectionRepository);
+
+    assert!(service.validate_connection("valid-connection"));
+    assert!(!service.validate_connection("invalid-connection"));
+}
+
+#[test]
+fn GivenAuditRepository_WhenAuditEntryIsRegistered_ThenService_ShouldPersistEntryThroughRepository()
+{
+    let entries = Rc::new(RefCell::new(Vec::new()));
+    let repository = TestAuditRepository {
+        entries: Rc::clone(&entries),
+    };
+    let service = AuditService::new(repository);
+
+    service.register_audit_entry("User logged in");
+
+    assert_eq!(entries.borrow().as_slice(), ["User logged in"]);
+}
+
+#[test]
+fn GivenConfigurationRepository_WhenValueIsRequested_ThenService_ShouldReturnValueFromRepository() {
+    let service = ConfigurationService::new(TestConfigurationRepository);
+
     assert_eq!(
-        greet("Carlos"),
-        "Hello, Carlos! You've been greeted from Rust!"
+        service.get_configuration_value("theme"),
+        Some("dark".to_owned())
     );
+    assert_eq!(service.get_configuration_value("timezone"), None);
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,3 +23,4 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sql-intelliscan-services = { path = "../crates/sql-intelliscan-services" }
+sql-intelliscan-repository = { path = "../crates/sql-intelliscan-repository" }

--- a/src-tauri/src/dependency_wiring/service_registry.rs
+++ b/src-tauri/src/dependency_wiring/service_registry.rs
@@ -1,5 +1,8 @@
-use sql_intelliscan_services::greet as greet_from_services;
+use sql_intelliscan_repository::StaticBackendMetadataRepository;
+use sql_intelliscan_services::GreetingService;
 
 pub fn greet_user(name: &str) -> String {
-    greet_from_services(name)
+    let service = GreetingService::new(StaticBackendMetadataRepository);
+
+    service.greet(name)
 }


### PR DESCRIPTION
### Motivation
- Introducir servicios de aplicación (use cases) que encapsulen la lógica de negocio para que los comandos Tauri deleguen en ellos en vez de contener lógica.
- Forzar inyección de dependencias por constructor para evitar que el crate de servicios instancie implementaciones concretas de repositorios.
- Exponer métodos públicos claros en los servicios para que la capa de aplicación los consuma fácilmente.

### Description
- Añadidos contratos de repositorio en `crates/sql-intelliscan-services/src/contracts` (`ConnectionRepository`, `AuditRepository`, `ConfigurationRepository`) y exportados desde `contracts/mod.rs`.
- Implementados servicios en `crates/sql-intelliscan-services/src/use_cases`: `ConnectionService`, `AuditService`, `ConfigurationService` y refactorizado `GreetingService` para recibir su repositorio por constructor.
- Actualizado `use_cases/mod.rs` y el root del crate (`lib.rs`) para exportar los nuevos servicios (`AuditService`, `ConfigurationService`, `ConnectionService`, `GreetingService`).
- Eliminada la función helper que instanciaba repositorios dentro del crate de servicios (la composición ahora se hace en la capa de aplicación).
- Actualizado wiring de la aplicación en `src-tauri/src/dependency_wiring/service_registry.rs` para componer `GreetingService` con `StaticBackendMetadataRepository` en la capa de Tauri.
- Añadida la dependencia `sql-intelliscan-repository` en `src-tauri/Cargo.toml` y añadidas pruebas unitarias en `crates/sql-intelliscan-services/tests/services.rs` que verifican la inyección por constructor y la delegación a repositorios.

### Testing
- Ejecutado `cargo test` (workspace) — todos los tests del backend y frontend pasaron (todos los suites ejecutados pasaron).
- Ejecutado `cargo test -p sql-intelliscan-services` — los tests del crate de servicios se ejecutaron y pasaron (4 tests OK).
- Ejecutado `cargo test -p sql-intelliscan` — los tests del crate de la aplicación pasaron.
- Ejecutado `python scripts/check-coverage.py` — falló debido a argumentos obligatorios faltantes (`--report --root --label`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5be0bdec8320b4a4a4374d5ea430)