### PR TITLE
Increase backend CI coverage with command and service registry contract tests

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,9 +3,12 @@ mod configuration;
 mod dependency_wiring;
 mod state;
 
+pub use commands::{
+    greet_command, register_handlers, validate_sql_server_connection_command,
+};
 pub use configuration::build_app;
+pub use dependency_wiring::{greet_user, validate_sql_server_connection};
 use configuration::run_builder;
-use dependency_wiring::greet_user;
 use state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};
 
 const DEFAULT_BUILDER_FACTORY: BuilderFactory = build_app;

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -1,0 +1,29 @@
+#![allow(non_snake_case)]
+
+use sql_intelliscan_lib::{
+    greet_command, register_handlers, validate_sql_server_connection_command,
+};
+use sql_intelliscan_services::errors::ServiceError;
+
+#[test]
+fn GivenValidName_WhenGreetCommandIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
+    let result = greet_command("Ana");
+
+    assert_eq!(result, "Hello, Ana! You've been greeted from Rust!");
+}
+
+#[test]
+fn GivenBuilder_WhenHandlersAreRegistered_ThenPipeline_ShouldBeComposable() {
+    let builder = tauri::Builder::default();
+
+    let _builder = register_handlers(builder);
+}
+
+#[test]
+fn GivenInvalidConnectionString_WhenValidateCommandIsCalled_ThenResult_ShouldReturnServiceError() {
+    let result = tauri::async_runtime::block_on(validate_sql_server_connection_command(
+        "Server=localhost;Database=master".to_owned(),
+    ));
+
+    assert_eq!(result, Err(ServiceError::InvalidConfiguration("missing username")));
+}

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -3,7 +3,6 @@
 use sql_intelliscan_lib::{
     greet_command, register_handlers, validate_sql_server_connection_command,
 };
-use sql_intelliscan_services::errors::ServiceError;
 
 #[test]
 fn GivenValidName_WhenGreetCommandIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
@@ -25,5 +24,6 @@ fn GivenInvalidConnectionString_WhenValidateCommandIsCalled_ThenResult_ShouldRet
         "Server=localhost;Database=master".to_owned(),
     ));
 
-    assert_eq!(result, Err(ServiceError::InvalidConfiguration("missing username")));
+    let error = result.expect_err("expected invalid configuration error");
+    assert_eq!(format!("{error:?}"), "InvalidConfiguration(\"missing username\")");
 }

--- a/tests/backend/service_registry.rs
+++ b/tests/backend/service_registry.rs
@@ -1,0 +1,32 @@
+#![allow(non_snake_case)]
+
+use sql_intelliscan_lib::{greet_user, validate_sql_server_connection};
+use sql_intelliscan_services::errors::ServiceError;
+
+#[test]
+fn GivenValidName_WhenGreetUserIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
+    let result = greet_user("Lucía");
+
+    assert_eq!(result, "Hello, Lucía! You've been greeted from Rust!");
+}
+
+#[test]
+fn GivenInvalidConnectionString_WhenValidationIsRequested_ThenResult_ShouldMapConfigurationError() {
+    let result = tauri::async_runtime::block_on(validate_sql_server_connection(
+        "Server=localhost;Database=master",
+    ));
+
+    assert_eq!(result, Err(ServiceError::InvalidConfiguration("missing username")));
+}
+
+#[test]
+fn GivenUnavailableServer_WhenValidationIsRequested_ThenResult_ShouldMapSourceUnavailable() {
+    let result = tauri::async_runtime::block_on(validate_sql_server_connection(
+        "Server=127.0.0.1,1;Database=master;User Id=sa;Password=bad-password;TrustServerCertificate=true;Encrypt=false;Connection Timeout=1",
+    ));
+
+    assert!(matches!(
+        result,
+        Err(ServiceError::SourceUnavailable) | Err(ServiceError::QueryExecutionFailed)
+    ));
+}

--- a/tests/backend/service_registry.rs
+++ b/tests/backend/service_registry.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
 
 use sql_intelliscan_lib::{greet_user, validate_sql_server_connection};
-use sql_intelliscan_services::errors::ServiceError;
 
 #[test]
 fn GivenValidName_WhenGreetUserIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
@@ -16,7 +15,8 @@ fn GivenInvalidConnectionString_WhenValidationIsRequested_ThenResult_ShouldMapCo
         "Server=localhost;Database=master",
     ));
 
-    assert_eq!(result, Err(ServiceError::InvalidConfiguration("missing username")));
+    let error = result.expect_err("expected invalid configuration error");
+    assert_eq!(format!("{error:?}"), "InvalidConfiguration(\"missing username\")");
 }
 
 #[test]
@@ -25,8 +25,10 @@ fn GivenUnavailableServer_WhenValidationIsRequested_ThenResult_ShouldMapSourceUn
         "Server=127.0.0.1,1;Database=master;User Id=sa;Password=bad-password;TrustServerCertificate=true;Encrypt=false;Connection Timeout=1",
     ));
 
-    assert!(matches!(
-        result,
-        Err(ServiceError::SourceUnavailable) | Err(ServiceError::QueryExecutionFailed)
-    ));
+    let error = result.expect_err("expected connection failure error");
+    let debug_error = format!("{error:?}");
+    assert!(
+        debug_error == "SourceUnavailable" || debug_error == "QueryExecutionFailed",
+        "unexpected error variant: {debug_error}"
+    );
 }


### PR DESCRIPTION
### Motivation
- The backend Tauri layer was below the CI coverage gate and needed additional contract-level tests to meet the minimum 80% requirement defined in `agents.md`.
- Some backend functions were not exported from the library entrypoint so contract tests could not exercise `commands` and `dependency_wiring` modules.
- Add focused contract tests to exercise command handlers and the service registry mapping logic to ensure coverage is measured for those files.

### Description
- Re-exported `greet_command`, `register_handlers`, and `validate_sql_server_connection_command` from `src-tauri/src/lib.rs` and also re-exported `greet_user` and `validate_sql_server_connection` to make these entrypoints available for contract tests.
- Added `tests/backend/commands.rs` with tests for `greet_command`, `register_handlers`, and invalid-connection validation mapping using `validate_sql_server_connection_command`.
- Added `tests/backend/service_registry.rs` with tests for `greet_user`, invalid connection-string configuration mapping, and unavailable-server mapping (accepting either `SourceUnavailable` or `QueryExecutionFailed` where appropriate).
- Kept test discovery compatible with the existing harness; no manual `[[test]]` entries were added to `Cargo.toml` so CI auto-discovery still applies.

### Testing
- Ran frontend coverage with `cargo llvm-cov --workspace --lib --test frontend` and verification via `python3 ./scripts/check-coverage.py`, yielding Frontend line coverage **91.38%**, which passed the `--min 80` gate.
- Ran backend contract coverage with `cargo llvm-cov --workspace --test backend_contracts` and `python3 ./scripts/check-coverage.py`, yielding Backend line coverage **91.96%**, which passed the `--min 80` gate after the new tests.
- Executed per-crate tests and coverage checks for the architectural layers, yielding Common **100.00%**, Repository **91.08%**, and Services **98.48%**, all above the 80% threshold.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09eec7600832089bd0d1acf6ce2d3)