### PR TITLE
feat(tauri): create shared AppState in src-tauri for Tauri command services

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,10 +1,13 @@
 use sql_intelliscan_services::{errors::ServiceError, models::ConnectionTestResult};
 
-use crate::dependency_wiring::{greet_user, validate_sql_server_connection};
+use crate::{
+    dependency_wiring::{greet_user, validate_sql_server_connection},
+    state::AppState,
+};
 
 #[tauri::command]
-pub fn greet_command(name: &str) -> String {
-    greet_user(name)
+pub fn greet_command(name: &str, state: tauri::State<'_, AppState>) -> String {
+    greet_user(name, state.inner())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,13 +1,14 @@
 use sql_intelliscan_services::{errors::ServiceError, models::ConnectionTestResult};
 
-use crate::{
-    dependency_wiring::{greet_user, validate_sql_server_connection},
-    state::AppState,
-};
+use crate::{dependency_wiring::validate_sql_server_connection, state::AppState};
+
+pub fn greet_command_handler(name: &str, state: &AppState) -> String {
+    state.greet(name)
+}
 
 #[tauri::command]
 pub(crate) fn greet_command(name: &str, state: tauri::State<'_, AppState>) -> String {
-    greet_user(name, state.inner())
+    greet_command_handler(name, state.inner())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 #[tauri::command]
-pub fn greet_command(name: &str, state: tauri::State<'_, AppState>) -> String {
+pub(crate) fn greet_command(name: &str, state: tauri::State<'_, AppState>) -> String {
     greet_user(name, state.inner())
 }
 

--- a/src-tauri/src/configuration/app_builder.rs
+++ b/src-tauri/src/configuration/app_builder.rs
@@ -1,7 +1,9 @@
-use crate::commands::register_handlers;
+use crate::{commands::register_handlers, dependency_wiring::create_app_state};
 
 pub fn build_app() -> tauri::Builder<tauri::Wry> {
-    register_handlers(tauri::Builder::default()).plugin(tauri_plugin_opener::init())
+    register_handlers(tauri::Builder::default())
+        .manage(create_app_state())
+        .plugin(tauri_plugin_opener::init())
 }
 
 pub fn run_builder(builder: tauri::Builder<tauri::Wry>) {

--- a/src-tauri/src/dependency_wiring/mod.rs
+++ b/src-tauri/src/dependency_wiring/mod.rs
@@ -1,3 +1,5 @@
 mod service_registry;
 
-pub use service_registry::{greet_user, validate_sql_server_connection};
+pub use service_registry::{
+    create_app_state, greet_user, validate_sql_server_connection, BackendMetadataRepositoryAdapter,
+};

--- a/src-tauri/src/dependency_wiring/mod.rs
+++ b/src-tauri/src/dependency_wiring/mod.rs
@@ -1,5 +1,5 @@
 mod service_registry;
 
-pub use service_registry::{
-    create_app_state, greet_user, validate_sql_server_connection, BackendMetadataRepositoryAdapter,
-};
+pub(crate) use service_registry::greet_user;
+pub(crate) use service_registry::BackendMetadataRepositoryAdapter;
+pub use service_registry::{create_app_state, validate_sql_server_connection};

--- a/src-tauri/src/dependency_wiring/service_registry.rs
+++ b/src-tauri/src/dependency_wiring/service_registry.rs
@@ -25,8 +25,8 @@ pub fn create_app_state() -> AppState {
     AppState::new(Arc::new(greeting_service))
 }
 
-pub fn greet_user(name: &str, state: &AppState) -> String {
-    state.greeting_service.greet(name)
+pub(crate) fn greet_user(name: &str, state: &AppState) -> String {
+    state.greet(name)
 }
 
 pub async fn validate_sql_server_connection(
@@ -43,7 +43,7 @@ pub async fn validate_sql_server_connection(
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct BackendMetadataRepositoryAdapter(pub StaticBackendMetadataRepository);
+pub(crate) struct BackendMetadataRepositoryAdapter(StaticBackendMetadataRepository);
 
 impl ServiceBackendMetadataRepository for BackendMetadataRepositoryAdapter {
     fn origin(&self) -> &'static str {

--- a/src-tauri/src/dependency_wiring/service_registry.rs
+++ b/src-tauri/src/dependency_wiring/service_registry.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use sql_intelliscan_repository::{
     BackendMetadataRepository as RepositoryBackendMetadataRepository,
     ConnectionRepository as RepositoryConnectionRepository, RepositoryError,
@@ -13,12 +15,18 @@ use sql_intelliscan_services::{
     ConnectionService, GreetingService,
 };
 
-pub fn greet_user(name: &str) -> String {
-    let service = GreetingService::new(BackendMetadataRepositoryAdapter(
+use crate::state::AppState;
+
+pub fn create_app_state() -> AppState {
+    let greeting_service = GreetingService::new(BackendMetadataRepositoryAdapter(
         StaticBackendMetadataRepository,
     ));
 
-    service.greet(name)
+    AppState::new(Arc::new(greeting_service))
+}
+
+pub fn greet_user(name: &str, state: &AppState) -> String {
+    state.greeting_service.greet(name)
 }
 
 pub async fn validate_sql_server_connection(
@@ -34,7 +42,8 @@ pub async fn validate_sql_server_connection(
     service.test_connection().await
 }
 
-struct BackendMetadataRepositoryAdapter(StaticBackendMetadataRepository);
+#[derive(Debug, Clone, Copy)]
+pub struct BackendMetadataRepositoryAdapter(pub StaticBackendMetadataRepository);
 
 impl ServiceBackendMetadataRepository for BackendMetadataRepositoryAdapter {
     fn origin(&self) -> &'static str {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,10 +3,13 @@ mod configuration;
 mod dependency_wiring;
 mod state;
 
-pub use commands::{register_handlers, validate_sql_server_connection_command};
+pub use commands::{
+    greet_command_handler, register_handlers, validate_sql_server_connection_command,
+};
 pub use configuration::build_app;
 use configuration::run_builder;
 pub use dependency_wiring::{create_app_state, validate_sql_server_connection};
+pub use state::AppState;
 use state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};
 
 const DEFAULT_BUILDER_FACTORY: BuilderFactory = build_app;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,12 +3,10 @@ mod configuration;
 mod dependency_wiring;
 mod state;
 
-pub use commands::{
-    greet_command, register_handlers, validate_sql_server_connection_command,
-};
+pub use commands::{greet_command, register_handlers, validate_sql_server_connection_command};
 pub use configuration::build_app;
-pub use dependency_wiring::{greet_user, validate_sql_server_connection};
 use configuration::run_builder;
+pub use dependency_wiring::{create_app_state, validate_sql_server_connection};
 use state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};
 
 const DEFAULT_BUILDER_FACTORY: BuilderFactory = build_app;
@@ -16,7 +14,9 @@ const DEFAULT_RUNNER: Runner = run_builder;
 const DEFAULT_BACKEND_RUNNER: BackendRunner = run;
 
 pub fn greet(name: &str) -> String {
-    greet_user(name)
+    let state = create_app_state();
+
+    dependency_wiring::greet_user(name, &state)
 }
 
 pub fn run_with(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod configuration;
 mod dependency_wiring;
 mod state;
 
-pub use commands::{greet_command, register_handlers, validate_sql_server_connection_command};
+pub use commands::{register_handlers, validate_sql_server_connection_command};
 pub use configuration::build_app;
 use configuration::run_builder;
 pub use dependency_wiring::{create_app_state, validate_sql_server_connection};

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -4,15 +4,19 @@ use sql_intelliscan_services::GreetingService;
 
 use crate::dependency_wiring::BackendMetadataRepositoryAdapter;
 
-pub type GreetingAppService = GreetingService<BackendMetadataRepositoryAdapter>;
+type GreetingAppService = GreetingService<BackendMetadataRepositoryAdapter>;
 
 #[derive(Clone)]
 pub struct AppState {
-    pub greeting_service: Arc<GreetingAppService>,
+    greeting_service: Arc<GreetingAppService>,
 }
 
 impl AppState {
-    pub fn new(greeting_service: Arc<GreetingAppService>) -> Self {
+    pub(crate) fn new(greeting_service: Arc<GreetingAppService>) -> Self {
         Self { greeting_service }
+    }
+
+    pub fn greet(&self, name: &str) -> String {
+        self.greeting_service.greet(name)
     }
 }

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use sql_intelliscan_services::GreetingService;
+
+use crate::dependency_wiring::BackendMetadataRepositoryAdapter;
+
+pub type GreetingAppService = GreetingService<BackendMetadataRepositoryAdapter>;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub greeting_service: Arc<GreetingAppService>,
+}
+
+impl AppState {
+    pub fn new(greeting_service: Arc<GreetingAppService>) -> Self {
+        Self { greeting_service }
+    }
+}

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -1,3 +1,5 @@
+mod app_state;
 mod runtime_state;
 
+pub use app_state::AppState;
 pub(crate) use runtime_state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -1,10 +1,15 @@
 #![allow(non_snake_case)]
 
-use sql_intelliscan_lib::{greet, register_handlers, validate_sql_server_connection_command};
+use sql_intelliscan_lib::{
+    create_app_state, greet_command_handler, register_handlers,
+    validate_sql_server_connection_command,
+};
 
 #[test]
-fn GivenValidName_WhenGreetFunctionIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
-    let result = greet("Ana");
+fn GivenManagedAppState_WhenGreetHandlerRuns_ThenMessage_ShouldUseBackendOrigin() {
+    let state = create_app_state();
+
+    let result = greet_command_handler("Ana", &state);
 
     assert_eq!(result, "Hello, Ana! You've been greeted from Rust!");
 }

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -1,12 +1,10 @@
 #![allow(non_snake_case)]
 
-use sql_intelliscan_lib::{
-    greet_command, register_handlers, validate_sql_server_connection_command,
-};
+use sql_intelliscan_lib::{greet, register_handlers, validate_sql_server_connection_command};
 
 #[test]
-fn GivenValidName_WhenGreetCommandIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
-    let result = greet_command("Ana");
+fn GivenValidName_WhenGreetFunctionIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
+    let result = greet("Ana");
 
     assert_eq!(result, "Hello, Ana! You've been greeted from Rust!");
 }

--- a/tests/backend/service_registry.rs
+++ b/tests/backend/service_registry.rs
@@ -10,7 +10,7 @@ fn GivenValidName_WhenGreetIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigi
 }
 
 #[test]
-fn GivenBuilder_WhenBuildAppIsCalled_ThenAppStateServices_ShouldBeRegistered() {
+fn GivenBackendBuilder_WhenAppIsComposed_ThenConfiguration_ShouldBuildWithoutRunningRuntime() {
     let _builder = build_app();
 }
 

--- a/tests/backend/service_registry.rs
+++ b/tests/backend/service_registry.rs
@@ -1,12 +1,17 @@
 #![allow(non_snake_case)]
 
-use sql_intelliscan_lib::{greet_user, validate_sql_server_connection};
+use sql_intelliscan_lib::{build_app, greet, validate_sql_server_connection};
 
 #[test]
-fn GivenValidName_WhenGreetUserIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
-    let result = greet_user("Lucía");
+fn GivenValidName_WhenGreetIsCalled_ThenMessage_ShouldIncludeNameAndBackendOrigin() {
+    let result = greet("Lucía");
 
     assert_eq!(result, "Hello, Lucía! You've been greeted from Rust!");
+}
+
+#[test]
+fn GivenBuilder_WhenBuildAppIsCalled_ThenAppStateServices_ShouldBeRegistered() {
+    let _builder = build_app();
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Provide a centralized, thread-safe container (AppState) in `src-tauri` so Tauri commands can access application services consistently. 
- Ensure shared dependencies are exposed as services (not repositories or SQL/business logic) and are safe to use from async commands using `Arc`.
- Avoid global mutable state and keep dependency access centralized in the composition layer.

### Description
- Added `AppState` in `src-tauri/src/state/app_state.rs` that holds shared services wrapped in `Arc` and exported via `src-tauri/src/state/mod.rs`.
- Added `create_app_state()` to `src-tauri/src/dependency_wiring/service_registry.rs` to compose/wire services at startup and kept repository/SQL adapters outside of `AppState`.
- Registered the state in the Tauri builder with `.manage(create_app_state())` in `src-tauri/src/configuration/app_builder.rs` and updated `greet_command` to accept `tauri::State<'_, AppState>` so commands access services through state.
- Updated `src-tauri/src/lib.rs` and backend tests (`tests/backend/*`) to use the new wiring and verify builder composition without introducing business or SQL logic into the state.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test` and all backend and frontend tests passed (backend and frontend suites executed successfully).
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and fixed issues so clippy finished without warnings.
- Executed the backend coverage flow (`cargo llvm-cov ...` + `python3 ./scripts/check-coverage.py`), resulting in Backend line coverage `90.08%`, which meets the CI threshold (>= 80%).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e85b66088320b2055c8426aa1204)