### PR TITLE
Introduce standardized command response models, split command modules, and update CI coverage reporting

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -1,13 +1,17 @@
 name: Build and Test
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      CARGO_TARGET_DIR: ${{ runner.temp }}/sql-intelliscan-target
-      CARGO_LLVM_COV_TARGET_DIR: ${{ runner.temp }}/sql-intelliscan-llvm-cov-target
+      CARGO_TARGET_DIR: /tmp/sql-intelliscan-target
+      CARGO_LLVM_COV_TARGET_DIR: /tmp/sql-intelliscan-llvm-cov-target
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -48,7 +52,7 @@ jobs:
           cargo test -p sql-intelliscan-services
       - name: Frontend wasm tests
         env:
-          CARGO_TARGET_DIR: ${{ runner.temp }}/sql-intelliscan-wasm-target
+          CARGO_TARGET_DIR: /tmp/sql-intelliscan-wasm-target
         run: bash ./scripts/wasm-test-local.sh
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
@@ -56,7 +60,7 @@ jobs:
         run: |
           cargo llvm-cov clean --workspace
           cargo llvm-cov --workspace --no-clean --no-report --lib --test frontend
-          cargo llvm-cov --workspace --no-clean --no-run --json > frontend-coverage.json
+          cargo llvm-cov report --json --output-path frontend-coverage.json
           python3 ./scripts/check-coverage.py \
             --report frontend-coverage.json \
             --root src \
@@ -67,7 +71,7 @@ jobs:
         run: |
           cargo llvm-cov clean --workspace
           cargo llvm-cov --workspace --no-clean --no-report --test backend_contracts
-          cargo llvm-cov --workspace --no-clean --no-run --json > backend-coverage.json
+          cargo llvm-cov report --json --output-path backend-coverage.json
           python3 ./scripts/check-coverage.py \
             --report backend-coverage.json \
             --root src-tauri/src \
@@ -78,7 +82,7 @@ jobs:
         run: |
           cargo llvm-cov clean --workspace
           cargo llvm-cov -p sql-intelliscan-common --no-clean --no-report
-          cargo llvm-cov -p sql-intelliscan-common --no-clean --no-run --json > common-coverage.json
+          cargo llvm-cov report --json --output-path common-coverage.json
           python3 ./scripts/check-coverage.py \
             --report common-coverage.json \
             --root crates/sql-intelliscan-common/src \
@@ -87,7 +91,7 @@ jobs:
 
           cargo llvm-cov clean --workspace
           cargo llvm-cov -p sql-intelliscan-repository --no-clean --no-report
-          cargo llvm-cov -p sql-intelliscan-repository --no-clean --no-run --json > repository-coverage.json
+          cargo llvm-cov report --json --output-path repository-coverage.json
           python3 ./scripts/check-coverage.py \
             --report repository-coverage.json \
             --root crates/sql-intelliscan-repository/src \
@@ -96,7 +100,7 @@ jobs:
 
           cargo llvm-cov clean --workspace
           cargo llvm-cov -p sql-intelliscan-services --no-clean --no-report
-          cargo llvm-cov -p sql-intelliscan-services --no-clean --no-run --json > services-coverage.json
+          cargo llvm-cov report --json --output-path services-coverage.json
           python3 ./scripts/check-coverage.py \
             --report services-coverage.json \
             --root crates/sql-intelliscan-services/src \

--- a/src-tauri/src/commands/connection_commands.rs
+++ b/src-tauri/src/commands/connection_commands.rs
@@ -1,0 +1,25 @@
+use sql_intelliscan_services::models::ConnectionTestResult;
+
+use crate::{AppState, CommandErrorResponse, CommandSuccessResponse};
+
+pub async fn validate_sql_server_connection_command(
+    state: tauri::State<'_, AppState>,
+    connection_string: String,
+) -> Result<CommandSuccessResponse<ConnectionTestResult>, CommandErrorResponse> {
+    validate_sql_server_connection_with_state(state.inner(), &connection_string)
+        .await
+        .map(|result| CommandSuccessResponse {
+            message: "Connection validated successfully".to_string(),
+            data: result,
+        })
+        .map_err(CommandErrorResponse::from_service_error)
+}
+
+pub async fn validate_sql_server_connection_with_state(
+    state: &AppState,
+    connection_string: &str,
+) -> sql_intelliscan_services::errors::ServiceResult<ConnectionTestResult> {
+    state
+        .validate_sql_server_connection(connection_string)
+        .await
+}

--- a/src-tauri/src/commands/greeting_commands.rs
+++ b/src-tauri/src/commands/greeting_commands.rs
@@ -1,0 +1,17 @@
+use crate::{state::AppState, CommandSuccessResponse};
+
+pub fn greet_command(
+    state: tauri::State<'_, AppState>,
+    name: &str,
+) -> CommandSuccessResponse<String> {
+    let message = greet_with_state(state.inner(), name);
+
+    CommandSuccessResponse {
+        message: "Greeting generated successfully".to_string(),
+        data: message,
+    }
+}
+
+pub fn greet_with_state(state: &AppState, name: &str) -> String {
+    state.greet(name)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,32 +1,36 @@
-use sql_intelliscan_services::{errors::ServiceError, models::ConnectionTestResult};
+mod connection_commands;
+mod greeting_commands;
+mod response_models;
+
 use tauri::State;
+
+pub use response_models::{CommandErrorResponse, CommandSuccessResponse};
+use sql_intelliscan_services::models::ConnectionTestResult;
 
 use crate::state::AppState;
 
 #[tauri::command]
-pub fn greet_command(state: State<'_, AppState>, name: &str) -> String {
-    greet_with_state(&state, name)
+pub fn greet_command(state: State<'_, AppState>, name: &str) -> CommandSuccessResponse<String> {
+    greeting_commands::greet_command(state, name)
 }
 
 #[tauri::command]
 pub async fn validate_sql_server_connection_command(
     state: State<'_, AppState>,
     connection_string: String,
-) -> Result<ConnectionTestResult, ServiceError> {
-    validate_sql_server_connection_with_state(&state, &connection_string).await
+) -> Result<CommandSuccessResponse<ConnectionTestResult>, CommandErrorResponse> {
+    connection_commands::validate_sql_server_connection_command(state, connection_string).await
 }
 
 pub fn greet_with_state(state: &AppState, name: &str) -> String {
-    state.greet(name)
+    greeting_commands::greet_with_state(state, name)
 }
 
 pub async fn validate_sql_server_connection_with_state(
     state: &AppState,
     connection_string: &str,
-) -> Result<ConnectionTestResult, ServiceError> {
-    state
-        .validate_sql_server_connection(connection_string)
-        .await
+) -> sql_intelliscan_services::errors::ServiceResult<ConnectionTestResult> {
+    connection_commands::validate_sql_server_connection_with_state(state, connection_string).await
 }
 
 pub fn register_handlers(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<tauri::Wry> {

--- a/src-tauri/src/commands/response_models.rs
+++ b/src-tauri/src/commands/response_models.rs
@@ -1,0 +1,42 @@
+use serde::Serialize;
+
+use sql_intelliscan_services::errors::ServiceError;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommandSuccessResponse<T>
+where
+    T: Serialize,
+{
+    pub message: String,
+    pub data: T,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommandErrorResponse {
+    pub message: String,
+}
+
+impl CommandErrorResponse {
+    pub fn from_service_error(error: ServiceError) -> Self {
+        let message = match error {
+            ServiceError::InvalidAuditRequest(_) => {
+                "The submitted audit request is invalid.".to_string()
+            }
+            ServiceError::InvalidConfiguration(reason) => {
+                format!("The provided configuration is invalid: {reason}.")
+            }
+            ServiceError::InvalidName => "The provided name is invalid.".to_string(),
+            ServiceError::QueryExecutionFailed => {
+                "The operation failed while querying the data source.".to_string()
+            }
+            ServiceError::ResultMappingFailed(_) => {
+                "The operation could not map the returned data.".to_string()
+            }
+            ServiceError::SourceUnavailable => {
+                "The data source is currently unavailable.".to_string()
+            }
+        };
+
+        Self { message }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod state;
 
 pub use commands::{
     greet_command, greet_with_state, register_handlers, validate_sql_server_connection_command,
-    validate_sql_server_connection_with_state,
+    validate_sql_server_connection_with_state, CommandErrorResponse, CommandSuccessResponse,
 };
 use configuration::run_builder;
 pub use configuration::{build_app, try_build_app};

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -2,7 +2,7 @@
 
 use sql_intelliscan_lib::{
     build_app_state, greet_with_state, register_handlers,
-    validate_sql_server_connection_with_state, ServiceError,
+    validate_sql_server_connection_with_state, CommandErrorResponse,
 };
 
 #[test]
@@ -22,7 +22,7 @@ fn GivenBuilder_WhenHandlersAreRegistered_ThenPipeline_ShouldBeComposable() {
 }
 
 #[test]
-fn GivenInvalidConnectionString_WhenValidateCommandHandlerIsCalled_ThenResult_ShouldReturnServiceError(
+fn GivenInvalidConnectionString_WhenValidateCommandHandlerIsCalled_ThenResult_ShouldReturnFriendlyError(
 ) {
     let app_state = build_app_state().expect("app state should build");
 
@@ -32,5 +32,10 @@ fn GivenInvalidConnectionString_WhenValidateCommandHandlerIsCalled_ThenResult_Sh
     ));
 
     let error = result.expect_err("expected invalid configuration error");
-    assert_eq!(error, ServiceError::InvalidConfiguration("missing username"));
+    let mapped_error = CommandErrorResponse::from_service_error(error);
+
+    assert_eq!(
+        mapped_error.message,
+        "The provided configuration is invalid: missing username."
+    );
 }


### PR DESCRIPTION
### Motivation

- Standardize Tauri command responses with friendly, serializable success/error wrappers for consistent frontend handling.
- Organize command logic into smaller modules to simplify testing and improve code separation.
- Update the CI workflow to modernize trigger events and adapt `cargo-llvm-cov` usage and temp directory handling for runner compatibility.

### Description

- Add `commands/response_models.rs` providing `CommandSuccessResponse<T>` and `CommandErrorResponse` and a `from_service_error` mapper for `ServiceError`.
- Extract command implementations into `commands/greeting_commands.rs` and `commands/connection_commands.rs` and delegate from `commands/mod.rs`, changing command signatures to return the new response types.
- Re-export `CommandErrorResponse` and `CommandSuccessResponse` from the crate root in `lib.rs` for public consumption.
- Update `.github/workflows/buildtest.yml` to include `pull_request_target` and `workflow_dispatch` triggers, use `/tmp` for `CARGO_TARGET_DIR` and `CARGO_LLVM_COV_TARGET_DIR`, and replace older `cargo llvm-cov` JSON flags with `cargo llvm-cov report --json --output-path`.

### Testing

- Updated unit test `tests/backend/commands.rs` to assert the friendly error message via `CommandErrorResponse::from_service_error` and ran `cargo test --workspace`.
- The updated backend command test and the workspace tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f235db623c83209fe0aedc05a8de50)