### PR TITLE
🔌 US-002.7 – Create frontend services in Leptos

### DIFF
--- a/src/services/connection_service.rs
+++ b/src/services/connection_service.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+
+use crate::services::tauri_client::{
+    invoke_validate_sql_server_connection, BackendConnectionTestResult, CommandErrorResponse,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionTestStatus {
+    pub is_valid: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrontendServiceError {
+    pub message: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ValidateConnectionArgs<'a> {
+    pub connection_string: &'a str,
+}
+
+pub async fn test_connection(
+    connection_string: &str,
+) -> Result<ConnectionTestStatus, FrontendServiceError> {
+    let connection_string = normalize_connection_string(connection_string)?;
+    let response = invoke_validate_sql_server_connection(connection_string)
+        .await
+        .map_err(normalize_backend_error)?;
+
+    Ok(map_connection_test_result(response.data))
+}
+
+pub fn map_connection_test_result(result: BackendConnectionTestResult) -> ConnectionTestStatus {
+    ConnectionTestStatus {
+        is_valid: result.is_valid,
+        message: result.message,
+    }
+}
+
+pub fn normalize_backend_error(error: CommandErrorResponse) -> FrontendServiceError {
+    FrontendServiceError {
+        message: normalize_error_message(&error.message),
+    }
+}
+
+fn normalize_connection_string(connection_string: &str) -> Result<&str, FrontendServiceError> {
+    let trimmed = connection_string.trim();
+
+    if trimmed.is_empty() {
+        return Err(FrontendServiceError {
+            message: "Connection string is required.".to_string(),
+        });
+    }
+
+    Ok(trimmed)
+}
+
+fn normalize_error_message(message: &str) -> String {
+    let trimmed = message.trim();
+
+    if trimmed.is_empty() {
+        return "The backend returned an unknown error.".to_string();
+    }
+
+    trimmed.to_string()
+}

--- a/src/services/connection_service.rs
+++ b/src/services/connection_service.rs
@@ -1,5 +1,6 @@
 use crate::services::tauri_client::{
     invoke_validate_sql_server_connection, BackendConnectionTestResult, CommandErrorResponse,
+    CommandSuccessResponse,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,13 +22,15 @@ pub async fn test_connection(
         .await
         .map_err(normalize_backend_error)?;
 
-    Ok(map_connection_test_result(response.data))
+    Ok(map_connection_test_result(response))
 }
 
-pub fn map_connection_test_result(result: BackendConnectionTestResult) -> ConnectionTestStatus {
+pub fn map_connection_test_result(
+    response: CommandSuccessResponse<BackendConnectionTestResult>,
+) -> ConnectionTestStatus {
     ConnectionTestStatus {
-        is_valid: result.is_valid,
-        message: result.message,
+        is_valid: response.data.is_valid,
+        message: response.message,
     }
 }
 

--- a/src/services/connection_service.rs
+++ b/src/services/connection_service.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::services::tauri_client::{
     invoke_validate_sql_server_connection, BackendConnectionTestResult, CommandErrorResponse,
 };
@@ -13,11 +11,6 @@ pub struct ConnectionTestStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FrontendServiceError {
     pub message: String,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct ValidateConnectionArgs<'a> {
-    pub connection_string: &'a str,
 }
 
 pub async fn test_connection(

--- a/src/services/greeting_service.rs
+++ b/src/services/greeting_service.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::services::tauri_client::invoke_backend_greet;
+use crate::services::tauri_client::{
+    invoke_backend_greet, CommandErrorResponse, CommandSuccessResponse,
+};
 
 #[derive(Deserialize, Serialize)]
 pub struct GreetResponse {
@@ -28,10 +30,18 @@ pub fn greet_message_sync(name: &str) -> Option<String> {
 pub async fn greet_message(name: &str) -> Option<String> {
     let normalized_name = normalized_name(name)?;
 
-    invoke_backend_greet(normalized_name)
-        .await
-        .ok()
-        .map(|response| response.data)
+    Some(map_greet_response(
+        invoke_backend_greet(normalized_name).await,
+    ))
+}
+
+pub fn map_greet_response(
+    response: Result<CommandSuccessResponse<String>, CommandErrorResponse>,
+) -> String {
+    match response {
+        Ok(response) => response.data,
+        Err(error) => error.message,
+    }
 }
 
 fn normalized_name(name: &str) -> Option<&str> {

--- a/src/services/greeting_service.rs
+++ b/src/services/greeting_service.rs
@@ -28,7 +28,10 @@ pub fn greet_message_sync(name: &str) -> Option<String> {
 pub async fn greet_message(name: &str) -> Option<String> {
     let normalized_name = normalized_name(name)?;
 
-    Some(invoke_backend_greet(normalized_name).await.message)
+    invoke_backend_greet(normalized_name)
+        .await
+        .ok()
+        .map(|response| response.data)
 }
 
 fn normalized_name(name: &str) -> Option<&str> {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,2 +1,3 @@
+pub mod connection_service;
 pub mod greeting_service;
 pub mod tauri_client;

--- a/src/services/tauri_client.rs
+++ b/src/services/tauri_client.rs
@@ -24,7 +24,6 @@ pub struct CommandErrorResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct BackendConnectionTestResult {
     pub is_valid: bool,
-    pub message: String,
 }
 
 #[derive(Serialize)]
@@ -113,10 +112,7 @@ pub async fn invoke_validate_sql_server_connection(
 
     Ok(CommandSuccessResponse {
         message: "Connection validated successfully".to_string(),
-        data: BackendConnectionTestResult {
-            is_valid: true,
-            message: "Connection validated successfully".to_string(),
-        },
+        data: BackendConnectionTestResult { is_valid: true },
     })
 }
 

--- a/src/services/tauri_client.rs
+++ b/src/services/tauri_client.rs
@@ -1,5 +1,6 @@
-use crate::services::greeting_service::GreetResponse;
-use serde::Serialize;
+#[cfg(target_arch = "wasm32")]
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -7,6 +8,28 @@ use wasm_bindgen::prelude::*;
 #[derive(Serialize)]
 pub struct GreetArgs<'a> {
     pub name: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CommandSuccessResponse<T> {
+    pub message: String,
+    pub data: T,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CommandErrorResponse {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct BackendConnectionTestResult {
+    pub is_valid: bool,
+    pub message: String,
+}
+
+#[derive(Serialize)]
+struct ValidateConnectionArgs<'a> {
+    connection_string: &'a str,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -26,38 +49,80 @@ extern "C" {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn invoke_backend_greet(name: &str) -> GreetResponse {
-    let args = match serde_wasm_bindgen::to_value(&GreetArgs { name }) {
-        Ok(args) => args,
-        Err(_) => {
-            return GreetResponse {
-                ok: false,
-                message: "The frontend could not prepare the greet arguments.".to_string(),
-            };
-        }
-    };
-
+async fn invoke_command<T, A>(
+    command: &str,
+    args: &A,
+) -> Result<CommandSuccessResponse<T>, CommandErrorResponse>
+where
+    T: DeserializeOwned,
+    A: Serialize,
+{
     if !has_tauri_invoke() {
-        return GreetResponse {
-            ok: true,
-            message: format!("Hello, {}! You've been greeted from Rust!", name),
-        };
+        return Err(CommandErrorResponse {
+            message: "Tauri backend is not available.".to_string(),
+        });
     }
 
-    let message = invoke("greet_command", args)
-        .await
-        .as_string()
-        .unwrap_or_else(|| "The backend returned a non-string greeting.".to_string());
+    let args = serde_wasm_bindgen::to_value(args).map_err(|_| CommandErrorResponse {
+        message: "The frontend could not prepare backend command arguments.".to_string(),
+    })?;
 
-    GreetResponse { ok: true, message }
+    let response = invoke(command, args).await;
+
+    serde_wasm_bindgen::from_value(response).map_err(|_| CommandErrorResponse {
+        message: "The backend returned an unexpected response.".to_string(),
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn invoke_backend_greet(
+    name: &str,
+) -> Result<CommandSuccessResponse<String>, CommandErrorResponse> {
+    if !has_tauri_invoke() {
+        return Ok(mock_greet_response(name));
+    }
+
+    invoke_command("greet_command", &GreetArgs { name }).await
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn invoke_validate_sql_server_connection(
+    connection_string: &str,
+) -> Result<CommandSuccessResponse<BackendConnectionTestResult>, CommandErrorResponse> {
+    invoke_command(
+        "validate_sql_server_connection_command",
+        &ValidateConnectionArgs { connection_string },
+    )
+    .await
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn invoke_backend_greet(name: &str) -> GreetResponse {
+pub async fn invoke_backend_greet(
+    name: &str,
+) -> Result<CommandSuccessResponse<String>, CommandErrorResponse> {
     let _args = GreetArgs { name };
 
-    GreetResponse {
-        ok: true,
-        message: format!("Hello, {}! You've been greeted from Rust!", name),
+    Ok(mock_greet_response(name))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn invoke_validate_sql_server_connection(
+    connection_string: &str,
+) -> Result<CommandSuccessResponse<BackendConnectionTestResult>, CommandErrorResponse> {
+    let _args = ValidateConnectionArgs { connection_string };
+
+    Ok(CommandSuccessResponse {
+        message: "Connection validated successfully".to_string(),
+        data: BackendConnectionTestResult {
+            is_valid: true,
+            message: "Connection validated successfully".to_string(),
+        },
+    })
+}
+
+fn mock_greet_response(name: &str) -> CommandSuccessResponse<String> {
+    CommandSuccessResponse {
+        message: "Greeting generated successfully".to_string(),
+        data: format!("Hello, {}! You've been greeted from Rust!", name),
     }
 }

--- a/tests/frontend/connection_service.rs
+++ b/tests/frontend/connection_service.rs
@@ -1,0 +1,54 @@
+#![allow(non_snake_case)]
+
+use sql_intelliscan_ui::services::connection_service::{
+    map_connection_test_result, normalize_backend_error, test_connection,
+};
+use sql_intelliscan_ui::services::tauri_client::{
+    BackendConnectionTestResult, CommandErrorResponse,
+};
+
+#[test]
+fn GivenBackendConnectionResult_WhenMapped_ThenFrontendModel_ShouldExposeFriendlyStatus() {
+    let status = map_connection_test_result(BackendConnectionTestResult {
+        is_valid: true,
+        message: "Connection validated successfully".to_string(),
+    });
+
+    assert!(status.is_valid);
+    assert_eq!(status.message, "Connection validated successfully");
+}
+
+#[test]
+fn GivenBackendErrorWithWhitespace_WhenNormalized_ThenServiceError_ShouldTrimMessage() {
+    let error = normalize_backend_error(CommandErrorResponse {
+        message: "  The provided configuration is invalid.  ".to_string(),
+    });
+
+    assert_eq!(error.message, "The provided configuration is invalid.");
+}
+
+#[test]
+fn GivenBackendErrorWithoutMessage_WhenNormalized_ThenServiceError_ShouldUseFallbackMessage() {
+    let error = normalize_backend_error(CommandErrorResponse {
+        message: " \t\n ".to_string(),
+    });
+
+    assert_eq!(error.message, "The backend returned an unknown error.");
+}
+
+#[test]
+fn GivenEmptyConnectionString_WhenConnectionIsTested_ThenService_ShouldReturnValidationError() {
+    let error = futures::executor::block_on(test_connection("  "))
+        .expect_err("empty connection string should be rejected by frontend service");
+
+    assert_eq!(error.message, "Connection string is required.");
+}
+
+#[test]
+fn GivenConnectionStringWithWhitespace_WhenConnectionIsTested_ThenService_ShouldUseTauriClient() {
+    let status = futures::executor::block_on(test_connection("  Server=localhost  "))
+        .expect("native frontend test uses a mocked Tauri client");
+
+    assert!(status.is_valid);
+    assert_eq!(status.message, "Connection validated successfully");
+}

--- a/tests/frontend/connection_service.rs
+++ b/tests/frontend/connection_service.rs
@@ -4,14 +4,14 @@ use sql_intelliscan_ui::services::connection_service::{
     map_connection_test_result, normalize_backend_error, test_connection,
 };
 use sql_intelliscan_ui::services::tauri_client::{
-    BackendConnectionTestResult, CommandErrorResponse,
+    BackendConnectionTestResult, CommandErrorResponse, CommandSuccessResponse,
 };
 
 #[test]
 fn GivenBackendConnectionResult_WhenMapped_ThenFrontendModel_ShouldExposeFriendlyStatus() {
-    let status = map_connection_test_result(BackendConnectionTestResult {
-        is_valid: true,
+    let status = map_connection_test_result(CommandSuccessResponse {
         message: "Connection validated successfully".to_string(),
+        data: BackendConnectionTestResult { is_valid: true },
     });
 
     assert!(status.is_valid);

--- a/tests/frontend/greeting_service.rs
+++ b/tests/frontend/greeting_service.rs
@@ -1,0 +1,23 @@
+#![allow(non_snake_case)]
+
+use sql_intelliscan_ui::services::greeting_service::map_greet_response;
+use sql_intelliscan_ui::services::tauri_client::{CommandErrorResponse, CommandSuccessResponse};
+
+#[test]
+fn GivenSuccessfulGreetResponse_WhenMapped_ThenMessage_ShouldUseBackendData() {
+    let message = map_greet_response(Ok(CommandSuccessResponse {
+        message: "Greeting generated successfully".to_string(),
+        data: "Hello, Frontend! You've been greeted from Rust!".to_string(),
+    }));
+
+    assert_eq!(message, "Hello, Frontend! You've been greeted from Rust!");
+}
+
+#[test]
+fn GivenFailedGreetResponse_WhenMapped_ThenMessage_ShouldExposeBackendError() {
+    let message = map_greet_response(Err(CommandErrorResponse {
+        message: "The backend returned an unexpected response.".to_string(),
+    }));
+
+    assert_eq!(message, "The backend returned an unexpected response.");
+}

--- a/tests/frontend/tauri_client.rs
+++ b/tests/frontend/tauri_client.rs
@@ -1,0 +1,26 @@
+#![allow(non_snake_case)]
+
+use sql_intelliscan_ui::services::tauri_client::{
+    invoke_backend_greet, invoke_validate_sql_server_connection,
+};
+
+#[test]
+fn GivenName_WhenGreetCommandIsInvoked_ThenMockedResponse_ShouldMatchBackendShape() {
+    let response = futures::executor::block_on(invoke_backend_greet("Carlos"))
+        .expect("native frontend test should use mocked Tauri response");
+
+    assert_eq!(response.message, "Greeting generated successfully");
+    assert_eq!(response.data, "Hello, Carlos! You've been greeted from Rust!");
+}
+
+#[test]
+fn GivenConnectionString_WhenValidateCommandIsInvoked_ThenMockedResponse_ShouldMatchBackendShape() {
+    let response = futures::executor::block_on(invoke_validate_sql_server_connection(
+        "Server=localhost;Database=master",
+    ))
+    .expect("native frontend test should use mocked Tauri response");
+
+    assert_eq!(response.message, "Connection validated successfully");
+    assert!(response.data.is_valid);
+    assert_eq!(response.data.message, "Connection validated successfully");
+}

--- a/tests/frontend/tauri_client.rs
+++ b/tests/frontend/tauri_client.rs
@@ -22,5 +22,4 @@ fn GivenConnectionString_WhenValidateCommandIsInvoked_ThenMockedResponse_ShouldM
 
     assert_eq!(response.message, "Connection validated successfully");
     assert!(response.data.is_valid);
-    assert_eq!(response.data.message, "Connection validated successfully");
 }


### PR DESCRIPTION
# 🔌 US-002.7 – Create frontend services in Leptos

---

## 📝 What?  
🧩 **Create frontend services in Leptos**  
Implement a `services` module in the Leptos frontend that abstracts all communication with Tauri backend commands, ensuring UI components interact with backend logic only through these services.

---

## 🤔 Why?  
🎯 **Motivation**  
- Decouple UI components from direct Tauri `invoke` calls.
- Centralize backend communication for maintainability and testability.
- Ensure consistent error handling and response mapping.
- Promote code reuse across components.

---

## 🛠️ How?  
🛠️ **Implementation Steps**  
- Created a `services` module in the frontend (`src/services/`).
- Implemented `connection_service.rs` to wrap the Tauri command for SQL Server connection validation.
- Added error normalization and response mapping to frontend-friendly models.
- Updated `greeting_service.rs` to use the new response structure.
- Refactored `tauri_client.rs` to provide generic command invocation and mock support for native tests.
- Ensured all backend calls from components go through service functions.
- Added comprehensive unit tests in `tests/frontend/` for both the service and the Tauri client adapter.

```mermaid
graph TD
    A[Leptos Component] -->|calls| B[Frontend Service]
    B -->|wraps| C[Tauri invoke]
    C -->|calls| D[Backend Command]
    D -->|returns| C
    C -->|maps response| B
    B -->|returns model| A
```

---

## 🧪 How to test?  
🧪 **Validation Scenarios**  
- **Scenario 1:** Components use service functions, not `invoke` directly.
- **Scenario 2:** Multiple components can reuse the same service.
- **Scenario 3:** Errors from backend are normalized and exposed in a consistent frontend format.
- **Unit tests:** Added in `tests/frontend/connection_service.rs` and `tests/frontend/tauri_client.rs` to cover mapping, error handling, and service logic.

---

## 📋 Acceptance Criteria Checklist

- [x] A `services` module exists in the frontend
- [x] Tauri `invoke` calls are encapsulated in service functions
- [x] Components do not call `invoke` directly
- [x] Responses are mapped to frontend-friendly models
- [x] Errors are handled and normalized
- [x] Services are reusable across multiple components
- [x] Workspace compiles successfully
- [x] At least one service wraps a Tauri command
- [x] Error handling implemented
- [x] Code is reusable and clean
- [x] `cargo fmt` passes
- [x] Workspace builds successfully

---

## 🗂️ Files changed summary

- **src/services/connection_service.rs**  
  - New service module: wraps backend connection validation, normalizes errors, maps responses.
- **src/services/greeting_service.rs**  
  - Refactored to use new response structure and error handling.
- **src/services/mod.rs**  
  - Exports the new `connection_service` module.
- **src/services/tauri_client.rs**  
  - Provides generic command invocation, backend response types, and mock support for tests.
- **tests/frontend/connection_service.rs**  
  - Unit tests for service logic, error normalization, and mapping.
- **tests/frontend/tauri_client.rs**  
  - Unit tests for Tauri client command invocation and response mapping.

---

## 🚦 Definition of Done

- [x] Frontend services module implemented
- [x] At least one service wraps a Tauri command
- [x] Components use services instead of `invoke`
- [x] Error handling implemented
- [x] Code is reusable and clean
- [x] `cargo fmt` passes
- [x] Workspace builds successfully

---

Close #31 