### PR TITLE
🧩 US-002.8 - Create mock implementations for repository contracts

### DIFF
--- a/crates/sql-intelliscan-services/tests/services.rs
+++ b/crates/sql-intelliscan-services/tests/services.rs
@@ -1,127 +1,22 @@
 #![allow(non_snake_case)]
 
-use std::cell::RefCell;
-use std::rc::Rc;
+mod test_utils;
 
 use sql_intelliscan_services::{
-    contracts::{
-        AuditRepository, BackendMetadataRepository, ConfigurationRepository, ConnectionRepository,
-        ConnectionRepositoryFactory,
-    },
-    errors::{DataAccessError, DataAccessResult, ServiceError},
+    errors::{DataAccessError, ServiceError},
     models::ConnectionTestResult,
     AuditService, ConfigurationService, ConnectionService, GreetingService,
 };
 
-struct TestBackendMetadataRepository;
-
-impl BackendMetadataRepository for TestBackendMetadataRepository {
-    fn origin(&self) -> &'static str {
-        "TestBackend"
-    }
-}
-
-struct TestConnectionRepository;
-
-impl ConnectionRepository for TestConnectionRepository {
-    async fn validate_connection(&self) -> DataAccessResult<bool> {
-        Ok(true)
-    }
-}
-
-struct FailingConnectionRepository;
-
-impl ConnectionRepository for FailingConnectionRepository {
-    async fn validate_connection(&self) -> DataAccessResult<bool> {
-        Err(DataAccessError::SourceUnavailable)
-    }
-}
-
-struct QueryFailingConnectionRepository;
-
-impl ConnectionRepository for QueryFailingConnectionRepository {
-    async fn validate_connection(&self) -> DataAccessResult<bool> {
-        Err(DataAccessError::QueryExecutionFailed("timeout".to_owned()))
-    }
-}
-
-struct MappingFailingConnectionRepository;
-
-impl ConnectionRepository for MappingFailingConnectionRepository {
-    async fn validate_connection(&self) -> DataAccessResult<bool> {
-        Err(DataAccessError::ResultMappingFailed(
-            "unexpected scalar type",
-        ))
-    }
-}
-
-struct InvalidConfigurationConnectionRepository;
-
-impl ConnectionRepository for InvalidConfigurationConnectionRepository {
-    async fn validate_connection(&self) -> DataAccessResult<bool> {
-        Err(DataAccessError::InvalidConfiguration("missing host"))
-    }
-}
-
-struct FalseConnectionRepository;
-
-impl ConnectionRepository for FalseConnectionRepository {
-    async fn validate_connection(&self) -> DataAccessResult<bool> {
-        Ok(false)
-    }
-}
-
-struct TestConnectionRepositoryFactory;
-
-impl ConnectionRepositoryFactory for TestConnectionRepositoryFactory {
-    type Repository = TestConnectionRepository;
-
-    fn build(&self, connection_string: &str) -> DataAccessResult<Self::Repository> {
-        if connection_string.trim().is_empty() {
-            return Err(DataAccessError::InvalidConfiguration(
-                "connection string is required",
-            ));
-        }
-
-        Ok(TestConnectionRepository)
-    }
-}
-
-struct FalseConnectionRepositoryFactory;
-
-impl ConnectionRepositoryFactory for FalseConnectionRepositoryFactory {
-    type Repository = FalseConnectionRepository;
-
-    fn build(&self, _connection_string: &str) -> DataAccessResult<Self::Repository> {
-        Ok(FalseConnectionRepository)
-    }
-}
-
-#[derive(Clone)]
-struct TestAuditRepository {
-    entries: Rc<RefCell<Vec<String>>>,
-}
-
-impl AuditRepository for TestAuditRepository {
-    fn save_entry(&self, entry: &str) {
-        self.entries.borrow_mut().push(entry.to_owned());
-    }
-}
-
-struct TestConfigurationRepository;
-
-impl ConfigurationRepository for TestConfigurationRepository {
-    fn find_value(&self, key: &str) -> Option<String> {
-        match key {
-            "theme" => Some("dark".to_owned()),
-            _ => None,
-        }
-    }
-}
+use test_utils::{
+    MockAuditRepository, MockBackendMetadataRepository, MockConfigurationRepository,
+    MockConnectionRepository, MockConnectionRepositoryFactory,
+};
 
 #[test]
 fn GivenRepositoryDouble_WhenGreetingIsRequested_ThenService_ShouldUseRepositoryOrigin() {
-    let service = GreetingService::new(TestBackendMetadataRepository);
+    let repository = MockBackendMetadataRepository::with_origin("TestBackend");
+    let service = GreetingService::new(repository);
 
     assert_eq!(
         service.greet("Carlos"),
@@ -132,7 +27,7 @@ fn GivenRepositoryDouble_WhenGreetingIsRequested_ThenService_ShouldUseRepository
 #[test]
 fn GivenConnectionRepository_WhenValidationIsRequested_ThenService_ShouldDelegateConnectivityCheck()
 {
-    let service = ConnectionService::new(TestConnectionRepository);
+    let service = ConnectionService::new(MockConnectionRepository::succeeds());
 
     let result = futures::executor::block_on(service.test_connection());
 
@@ -141,7 +36,7 @@ fn GivenConnectionRepository_WhenValidationIsRequested_ThenService_ShouldDelegat
 
 #[test]
 fn GivenConnectionRepository_WhenBooleanValidationIsRequested_ThenService_ShouldReturnBoolean() {
-    let service = ConnectionService::new(TestConnectionRepository);
+    let service = ConnectionService::new(MockConnectionRepository::succeeds());
 
     let result = futures::executor::block_on(service.validate_connection());
 
@@ -151,7 +46,7 @@ fn GivenConnectionRepository_WhenBooleanValidationIsRequested_ThenService_Should
 #[test]
 fn GivenConnectionRepositoryReturnsFalse_WhenValidationIsRequested_ThenService_ShouldReturnInvalidResult(
 ) {
-    let service = ConnectionService::new(FalseConnectionRepository);
+    let service = ConnectionService::new(MockConnectionRepository::rejects_connection());
 
     let result = futures::executor::block_on(service.test_connection());
 
@@ -161,7 +56,9 @@ fn GivenConnectionRepositoryReturnsFalse_WhenValidationIsRequested_ThenService_S
 #[test]
 fn GivenConnectionRepositoryFailure_WhenValidationIsRequested_ThenService_ShouldReturnServiceError()
 {
-    let service = ConnectionService::new(FailingConnectionRepository);
+    let service = ConnectionService::new(MockConnectionRepository::fails_with(
+        DataAccessError::SourceUnavailable,
+    ));
 
     let result = futures::executor::block_on(service.test_connection());
 
@@ -170,7 +67,9 @@ fn GivenConnectionRepositoryFailure_WhenValidationIsRequested_ThenService_Should
 
 #[test]
 fn GivenRepositoryQueryFailure_WhenValidationIsRequested_ThenService_ShouldNormalizeError() {
-    let service = ConnectionService::new(QueryFailingConnectionRepository);
+    let service = ConnectionService::new(MockConnectionRepository::fails_with(
+        DataAccessError::QueryExecutionFailed("timeout".to_owned()),
+    ));
 
     let result = futures::executor::block_on(service.test_connection());
 
@@ -179,7 +78,9 @@ fn GivenRepositoryQueryFailure_WhenValidationIsRequested_ThenService_ShouldNorma
 
 #[test]
 fn GivenRepositoryMappingFailure_WhenValidationIsRequested_ThenService_ShouldNormalizeError() {
-    let service = ConnectionService::new(MappingFailingConnectionRepository);
+    let service = ConnectionService::new(MockConnectionRepository::fails_with(
+        DataAccessError::ResultMappingFailed("unexpected scalar type"),
+    ));
 
     let result = futures::executor::block_on(service.test_connection());
 
@@ -192,7 +93,9 @@ fn GivenRepositoryMappingFailure_WhenValidationIsRequested_ThenService_ShouldNor
 #[test]
 fn GivenRepositoryConfigurationFailure_WhenValidationIsRequested_ThenService_ShouldNormalizeError()
 {
-    let service = ConnectionService::new(InvalidConfigurationConnectionRepository);
+    let service = ConnectionService::new(MockConnectionRepository::fails_with(
+        DataAccessError::InvalidConfiguration("missing host"),
+    ));
 
     let result = futures::executor::block_on(service.test_connection());
 
@@ -205,18 +108,27 @@ fn GivenRepositoryConfigurationFailure_WhenValidationIsRequested_ThenService_Sho
 #[test]
 fn GivenConnectionRepositoryFactory_WhenConfiguredValidationIsRequested_ThenService_ShouldBuildRepository(
 ) {
-    let service = ConnectionService::new(TestConnectionRepositoryFactory);
+    let repository = MockConnectionRepository::succeeds();
+    let factory = MockConnectionRepositoryFactory::builds(repository);
+    let service = ConnectionService::new(factory.clone());
 
     let result =
         futures::executor::block_on(service.test_configured_connection("Server=localhost"));
 
     assert_eq!(result, Ok(ConnectionTestResult::valid()));
+    assert_eq!(
+        factory.requested_connection_strings(),
+        ["Server=localhost".to_owned()]
+    );
 }
 
 #[test]
 fn GivenInvalidConnectionConfiguration_WhenConfiguredValidationIsRequested_ThenService_ShouldReturnValidationError(
 ) {
-    let service = ConnectionService::new(TestConnectionRepositoryFactory);
+    let factory = MockConnectionRepositoryFactory::fails_with(
+        DataAccessError::InvalidConfiguration("connection string is required"),
+    );
+    let service = ConnectionService::new(factory);
 
     let result = futures::executor::block_on(service.test_configured_connection(" "));
 
@@ -231,7 +143,9 @@ fn GivenInvalidConnectionConfiguration_WhenConfiguredValidationIsRequested_ThenS
 #[test]
 fn GivenConnectionRepositoryFactory_WhenConfiguredBooleanValidationIsRequested_ThenService_ShouldReturnBoolean(
 ) {
-    let service = ConnectionService::new(FalseConnectionRepositoryFactory);
+    let repository = MockConnectionRepository::rejects_connection();
+    let factory = MockConnectionRepositoryFactory::builds(repository);
+    let service = ConnectionService::new(factory);
 
     let result =
         futures::executor::block_on(service.validate_configured_connection("Server=localhost"));
@@ -242,39 +156,30 @@ fn GivenConnectionRepositoryFactory_WhenConfiguredBooleanValidationIsRequested_T
 #[test]
 fn GivenAuditRepository_WhenAuditEntryIsRegistered_ThenService_ShouldPersistEntryThroughRepository()
 {
-    let entries = Rc::new(RefCell::new(Vec::new()));
-    let repository = TestAuditRepository {
-        entries: Rc::clone(&entries),
-    };
-    let service = AuditService::new(repository);
+    let repository = MockAuditRepository::default();
+    let service = AuditService::new(repository.clone());
 
     let result = service.start_audit_execution(" User logged in ");
 
     assert_eq!(result, Ok(()));
-    assert_eq!(entries.borrow().as_slice(), ["User logged in"]);
+    assert_eq!(repository.entries(), ["User logged in"]);
 }
 
 #[test]
 fn GivenAuditRepository_WhenRawAuditEntryIsRegistered_ThenService_ShouldPersistEntryThroughRepository(
 ) {
-    let entries = Rc::new(RefCell::new(Vec::new()));
-    let repository = TestAuditRepository {
-        entries: Rc::clone(&entries),
-    };
-    let service = AuditService::new(repository);
+    let repository = MockAuditRepository::default();
+    let service = AuditService::new(repository.clone());
 
     service.register_audit_entry("User logged in");
 
-    assert_eq!(entries.borrow().as_slice(), ["User logged in"]);
+    assert_eq!(repository.entries(), ["User logged in"]);
 }
 
 #[test]
 fn GivenBlankAuditRequest_WhenAuditExecutionStarts_ThenService_ShouldReturnValidationError() {
-    let entries = Rc::new(RefCell::new(Vec::new()));
-    let repository = TestAuditRepository {
-        entries: Rc::clone(&entries),
-    };
-    let service = AuditService::new(repository);
+    let repository = MockAuditRepository::default();
+    let service = AuditService::new(repository.clone());
 
     let result = service.start_audit_execution(" ");
 
@@ -284,12 +189,13 @@ fn GivenBlankAuditRequest_WhenAuditExecutionStarts_ThenService_ShouldReturnValid
             "request name is required"
         ))
     );
-    assert!(entries.borrow().is_empty());
+    assert!(repository.entries().is_empty());
 }
 
 #[test]
 fn GivenConfigurationRepository_WhenValueIsRequested_ThenService_ShouldReturnValueFromRepository() {
-    let service = ConfigurationService::new(TestConfigurationRepository);
+    let repository = MockConfigurationRepository::default().with_value("theme", "dark");
+    let service = ConfigurationService::new(repository);
 
     assert_eq!(
         service.get_configuration_value("theme"),
@@ -301,7 +207,8 @@ fn GivenConfigurationRepository_WhenValueIsRequested_ThenService_ShouldReturnVal
 #[test]
 fn GivenConfigurationRepository_WhenConfigurationIsLoaded_ThenService_ShouldValidateAndNormalizeKey(
 ) {
-    let service = ConfigurationService::new(TestConfigurationRepository);
+    let repository = MockConfigurationRepository::default().with_value("theme", "dark");
+    let service = ConfigurationService::new(repository);
 
     let result = service.load_configuration_value(" theme ");
 
@@ -310,7 +217,7 @@ fn GivenConfigurationRepository_WhenConfigurationIsLoaded_ThenService_ShouldVali
 
 #[test]
 fn GivenBlankConfigurationKey_WhenConfigurationIsLoaded_ThenService_ShouldReturnValidationError() {
-    let service = ConfigurationService::new(TestConfigurationRepository);
+    let service = ConfigurationService::new(MockConfigurationRepository::default());
 
     let result = service.load_configuration_value(" ");
 

--- a/crates/sql-intelliscan-services/tests/services.rs
+++ b/crates/sql-intelliscan-services/tests/services.rs
@@ -128,7 +128,7 @@ fn GivenInvalidConnectionConfiguration_WhenConfiguredValidationIsRequested_ThenS
     let factory = MockConnectionRepositoryFactory::fails_with(
         DataAccessError::InvalidConfiguration("connection string is required"),
     );
-    let service = ConnectionService::new(factory);
+    let service = ConnectionService::new(factory.clone());
 
     let result = futures::executor::block_on(service.test_configured_connection(" "));
 
@@ -138,6 +138,7 @@ fn GivenInvalidConnectionConfiguration_WhenConfiguredValidationIsRequested_ThenS
             "connection string is required"
         ))
     );
+    assert_eq!(factory.requested_connection_strings(), [" ".to_owned()]);
 }
 
 #[test]

--- a/crates/sql-intelliscan-services/tests/test_utils/mock_audit_repository.rs
+++ b/crates/sql-intelliscan-services/tests/test_utils/mock_audit_repository.rs
@@ -1,0 +1,21 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use sql_intelliscan_services::contracts::AuditRepository;
+
+#[derive(Clone, Debug, Default)]
+pub struct MockAuditRepository {
+    entries: Rc<RefCell<Vec<String>>>,
+}
+
+impl MockAuditRepository {
+    pub fn entries(&self) -> Vec<String> {
+        self.entries.borrow().clone()
+    }
+}
+
+impl AuditRepository for MockAuditRepository {
+    fn save_entry(&self, entry: &str) {
+        self.entries.borrow_mut().push(entry.to_owned());
+    }
+}

--- a/crates/sql-intelliscan-services/tests/test_utils/mock_backend_metadata_repository.rs
+++ b/crates/sql-intelliscan-services/tests/test_utils/mock_backend_metadata_repository.rs
@@ -1,0 +1,18 @@
+use sql_intelliscan_services::contracts::BackendMetadataRepository;
+
+#[derive(Clone, Copy, Debug)]
+pub struct MockBackendMetadataRepository {
+    origin: &'static str,
+}
+
+impl MockBackendMetadataRepository {
+    pub fn with_origin(origin: &'static str) -> Self {
+        Self { origin }
+    }
+}
+
+impl BackendMetadataRepository for MockBackendMetadataRepository {
+    fn origin(&self) -> &'static str {
+        self.origin
+    }
+}

--- a/crates/sql-intelliscan-services/tests/test_utils/mock_configuration_repository.rs
+++ b/crates/sql-intelliscan-services/tests/test_utils/mock_configuration_repository.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+
+use sql_intelliscan_services::contracts::ConfigurationRepository;
+
+#[derive(Clone, Debug, Default)]
+pub struct MockConfigurationRepository {
+    values: HashMap<String, String>,
+}
+
+impl MockConfigurationRepository {
+    pub fn with_value(mut self, key: &str, value: &str) -> Self {
+        self.values.insert(key.to_owned(), value.to_owned());
+        self
+    }
+}
+
+impl ConfigurationRepository for MockConfigurationRepository {
+    fn find_value(&self, key: &str) -> Option<String> {
+        self.values.get(key).cloned()
+    }
+}

--- a/crates/sql-intelliscan-services/tests/test_utils/mock_connection_repository.rs
+++ b/crates/sql-intelliscan-services/tests/test_utils/mock_connection_repository.rs
@@ -1,0 +1,69 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use sql_intelliscan_services::{
+    contracts::{ConnectionRepository, ConnectionRepositoryFactory},
+    errors::{DataAccessError, DataAccessResult},
+};
+
+#[derive(Clone, Debug)]
+pub struct MockConnectionRepository {
+    result: DataAccessResult<bool>,
+}
+
+impl MockConnectionRepository {
+    pub fn succeeds() -> Self {
+        Self { result: Ok(true) }
+    }
+
+    pub fn rejects_connection() -> Self {
+        Self { result: Ok(false) }
+    }
+
+    pub fn fails_with(error: DataAccessError) -> Self {
+        Self { result: Err(error) }
+    }
+}
+
+impl ConnectionRepository for MockConnectionRepository {
+    async fn validate_connection(&self) -> DataAccessResult<bool> {
+        self.result.clone()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MockConnectionRepositoryFactory {
+    build_result: DataAccessResult<MockConnectionRepository>,
+    requested_connection_strings: Rc<RefCell<Vec<String>>>,
+}
+
+impl MockConnectionRepositoryFactory {
+    pub fn builds(repository: MockConnectionRepository) -> Self {
+        Self {
+            build_result: Ok(repository),
+            requested_connection_strings: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+
+    pub fn fails_with(error: DataAccessError) -> Self {
+        Self {
+            build_result: Err(error),
+            requested_connection_strings: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+
+    pub fn requested_connection_strings(&self) -> Vec<String> {
+        self.requested_connection_strings.borrow().clone()
+    }
+}
+
+impl ConnectionRepositoryFactory for MockConnectionRepositoryFactory {
+    type Repository = MockConnectionRepository;
+
+    fn build(&self, connection_string: &str) -> DataAccessResult<Self::Repository> {
+        self.requested_connection_strings
+            .borrow_mut()
+            .push(connection_string.to_owned());
+        self.build_result.clone()
+    }
+}

--- a/crates/sql-intelliscan-services/tests/test_utils/mod.rs
+++ b/crates/sql-intelliscan-services/tests/test_utils/mod.rs
@@ -1,0 +1,9 @@
+mod mock_audit_repository;
+mod mock_backend_metadata_repository;
+mod mock_configuration_repository;
+mod mock_connection_repository;
+
+pub use mock_audit_repository::MockAuditRepository;
+pub use mock_backend_metadata_repository::MockBackendMetadataRepository;
+pub use mock_configuration_repository::MockConfigurationRepository;
+pub use mock_connection_repository::{MockConnectionRepository, MockConnectionRepositoryFactory};


### PR DESCRIPTION
# 🧩 US-002.8 - Create mock implementations for repository contracts

## 📝 What

🧩 **Create mock implementations for repository contracts in the `services` crate.**  
This enables service-level unit tests to run without requiring SQL Server, `mssqlrust`, or the Tauri runtime.

---

## 💡 Why

🔍 **To allow isolated, fast, and reliable unit testing of service logic**  
- Avoids the need for real database or runtime dependencies during tests  
- Enables simulation of both success and failure scenarios  
- Ensures services correctly map repository errors to service errors  
- Improves test speed and developer productivity

---

## 🛠️ How

1. **Created mock implementations for core repository traits:**
   - `MockConnectionRepository` and `MockConnectionRepositoryFactory`
   - `MockBackendMetadataRepository`
   - `MockAuditRepository`
   - `MockConfigurationRepository`
2. **Placed all mocks in `crates/sql-intelliscan-services/tests/test_utils/` and re-exported via `mod.rs` for easy use.**
3. **Refactored service tests to use these mocks instead of real or ad-hoc test doubles.**
4. **Ensured mocks can simulate both success and failure, and can record/inspect calls.**
5. **No production code is affected; mocks are only available to tests.**
6. **All acceptance criteria and validation scenarios from the user story are covered.**

```mermaid
flowchart TD
    subgraph Test Layer
        SVC[Service Under Test]
        MOCK_CONN[MockConnectionRepository]
        MOCK_FACTORY[MockConnectionRepositoryFactory]
        MOCK_AUDIT[MockAuditRepository]
        MOCK_CONFIG[MockConfigurationRepository]
        MOCK_META[MockBackendMetadataRepository]
    end
    SVC -- uses --> MOCK_CONN
    SVC -- uses --> MOCK_FACTORY
    SVC -- uses --> MOCK_AUDIT
    SVC -- uses --> MOCK_CONFIG
    SVC -- uses --> MOCK_META
    MOCK_CONN -.->|Simulate success/failure| SVC
    MOCK_FACTORY -.->|Track connection strings| SVC
    MOCK_AUDIT -.->|Record entries| SVC
    MOCK_CONFIG -.->|Return config values| SVC
    MOCK_META -.->|Return origin| SVC
```

---

## 🧪 How to test

1. Run all service tests:
   ```
   cargo test -p sql-intelliscan-services
   ```
2. Confirm that:
   - No SQL Server, Tauri, or `mssqlrust` is required
   - Both success and failure scenarios are tested
   - Mocks are only used in test code
3. Check that:
   - `cargo fmt` and `cargo clippy` pass
   - Workspace builds successfully

---

## 🗂️ Files changed summary

- **crates/sql-intelliscan-services/tests/services.rs**
  - Refactored to use new mock implementations for all repository contracts.
- **crates/sql-intelliscan-services/tests/test_utils/mock_connection_repository.rs**
  - Added: Mocks for `ConnectionRepository` and `ConnectionRepositoryFactory`.
- **crates/sql-intelliscan-services/tests/test_utils/mock_backend_metadata_repository.rs**
  - Added: Mock for `BackendMetadataRepository`.
- **crates/sql-intelliscan-services/tests/test_utils/mock_audit_repository.rs**
  - Added: Mock for `AuditRepository`.
- **crates/sql-intelliscan-services/tests/test_utils/mock_configuration_repository.rs**
  - Added: Mock for `ConfigurationRepository`.
- **crates/sql-intelliscan-services/tests/test_utils/mod.rs**
  - Re-exports all mocks for easy use in tests.

---

## ☑️ Checklist

- [x] Mock implementations exist for core repository traits
- [x] Service tests can run without SQL Server
- [x] Service tests can run without Tauri runtime
- [x] Tests do not require `mssqlrust`
- [x] Mocks are isolated to test modules or test utilities
- [x] Success scenarios are covered
- [x] Failure scenarios are covered
- [x] Repository errors can be simulated
- [x] Services correctly map repository errors into service errors
- [x] Workspace compiles successfully
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes

---

## 📚 References

- User Story: [🧩 US-002.8 - Create mock implementations for repository contracts](#33)
- [agents.md](agents.md) (testing rules and conventions)

---

Close #33 