### PR TITLE
feat(repository): SQL Server connection config model with validation and secret masking

### DIFF
--- a/crates/sql-intelliscan-repository/src/lib.rs
+++ b/crates/sql-intelliscan-repository/src/lib.rs
@@ -7,5 +7,5 @@ pub mod sql_server;
 pub use contracts::{BackendMetadataRepository, ConnectionRepository};
 pub use data_access::StaticBackendMetadataRepository;
 pub use errors::{RepositoryError, RepositoryResult};
-pub use models::{BackendMetadata, SqlServerConnectionConfig};
+pub use models::{BackendMetadata, ConnectionConfigValidationError, SqlServerConnectionConfig};
 pub use sql_server::{SqlServerConnectionRepository, SqlServerMetadataRepository};

--- a/crates/sql-intelliscan-repository/src/models/mod.rs
+++ b/crates/sql-intelliscan-repository/src/models/mod.rs
@@ -2,4 +2,6 @@ mod backend_metadata;
 mod sql_server_connection_config;
 
 pub use backend_metadata::BackendMetadata;
-pub use sql_server_connection_config::SqlServerConnectionConfig;
+pub use sql_server_connection_config::{
+    ConnectionConfigValidationError, SqlServerConnectionConfig,
+};

--- a/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
@@ -165,14 +165,15 @@ impl SqlServerConnectionConfig {
                     config.trust_server_certificate =
                         matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes")
                 }
-                "encrypt" => {
-                    config.encrypt =
-                        !matches!(value.to_ascii_lowercase().as_str(), "false" | "0" | "no")
-                }
+                "encrypt" => match value.to_ascii_lowercase().as_str() {
+                    "true" | "1" | "yes" => config.encrypt = true,
+                    "false" | "0" | "no" => config.encrypt = false,
+                    _ => return Err(RepositoryError::InvalidConfiguration("invalid encrypt")),
+                },
                 "connection timeout" | "connect timeout" => {
-                    if let Ok(parsed_timeout) = value.parse::<u64>() {
-                        config.connection_timeout_seconds = parsed_timeout;
-                    }
+                    config.connection_timeout_seconds = value
+                        .parse::<u64>()
+                        .map_err(|_| RepositoryError::InvalidConfiguration("invalid timeout"))?;
                 }
                 "application name" => {
                     config.application_name = if value.is_empty() {

--- a/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
@@ -147,11 +147,15 @@ impl SqlServerConnectionConfig {
                 "server" | "data source" => {
                     let mut host_parts = value.split(',');
                     config.host = host_parts.next().unwrap_or_default().trim().to_owned();
-                    if let Some(parsed_port) = host_parts
-                        .next()
-                        .and_then(|item| item.trim().parse::<u16>().ok())
-                    {
-                        config.port = parsed_port;
+                    if let Some(port) = host_parts.next() {
+                        if host_parts.next().is_some() {
+                            return Err(RepositoryError::InvalidConfiguration("invalid port"));
+                        }
+
+                        config.port = port
+                            .trim()
+                            .parse::<u16>()
+                            .map_err(|_| RepositoryError::InvalidConfiguration("invalid port"))?;
                     }
                 }
                 "user id" | "uid" | "user" => config.username = value.to_owned(),

--- a/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
@@ -66,6 +66,20 @@ pub enum ConnectionConfigValidationError {
     InvalidApplicationName,
 }
 
+impl ConnectionConfigValidationError {
+    fn as_repository_message(&self) -> &'static str {
+        match self {
+            Self::HostRequired => "missing host",
+            Self::DatabaseRequired => "missing database",
+            Self::UsernameRequired => "missing username",
+            Self::PasswordRequired => "missing password",
+            Self::InvalidPort => "invalid port",
+            Self::InvalidTimeout => "invalid timeout",
+            Self::InvalidApplicationName => "invalid application name",
+        }
+    }
+}
+
 impl SqlServerConnectionConfig {
     pub fn validate(&self) -> Result<(), Vec<ConnectionConfigValidationError>> {
         let mut errors = Vec::new();
@@ -163,8 +177,12 @@ impl SqlServerConnectionConfig {
             }
         }
 
-        config.validate().map_err(|_| {
-            RepositoryError::InvalidConfiguration("invalid SQL Server connection configuration")
+        config.validate().map_err(|errors| {
+            let first = errors
+                .first()
+                .map(ConnectionConfigValidationError::as_repository_message)
+                .unwrap_or("invalid SQL Server connection configuration");
+            RepositoryError::InvalidConfiguration(first)
         })?;
 
         Ok(config)

--- a/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
@@ -124,7 +124,11 @@ impl SqlServerConnectionConfig {
     }
 
     pub fn from_connection_string(connection_string: &str) -> RepositoryResult<Self> {
-        let mut config = Self::default();
+        let mut config = Self {
+            host: String::new(),
+            database: String::new(),
+            ..Self::default()
+        };
 
         for token in connection_string
             .split(';')

--- a/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/src/models/sql_server_connection_config.rs
@@ -1,23 +1,116 @@
+use std::fmt;
+
 use crate::errors::{RepositoryError, RepositoryResult};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+const DEFAULT_PORT: u16 = 1433;
+const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
+const MAX_TIMEOUT_SECONDS: u64 = 300;
+const DEFAULT_APPLICATION_NAME: &str = "SQL Intelliscan";
+
+#[derive(Clone, PartialEq, Eq)]
 pub struct SqlServerConnectionConfig {
     pub host: String,
     pub port: u16,
+    pub database: String,
     pub username: String,
     pub password: String,
-    pub database: String,
-    pub trust_cert: bool,
+    pub encrypt: bool,
+    pub trust_server_certificate: bool,
+    pub connection_timeout_seconds: u64,
+    pub application_name: Option<String>,
+}
+
+impl fmt::Debug for SqlServerConnectionConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SqlServerConnectionConfig")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("database", &self.database)
+            .field("username", &self.username)
+            .field("password", &"***")
+            .field("encrypt", &self.encrypt)
+            .field("trust_server_certificate", &self.trust_server_certificate)
+            .field(
+                "connection_timeout_seconds",
+                &self.connection_timeout_seconds,
+            )
+            .field("application_name", &self.application_name)
+            .finish()
+    }
+}
+
+impl Default for SqlServerConnectionConfig {
+    fn default() -> Self {
+        Self {
+            host: "localhost".to_owned(),
+            port: DEFAULT_PORT,
+            database: "master".to_owned(),
+            username: String::new(),
+            password: String::new(),
+            encrypt: true,
+            trust_server_certificate: false,
+            connection_timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
+            application_name: Some(DEFAULT_APPLICATION_NAME.to_owned()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionConfigValidationError {
+    HostRequired,
+    DatabaseRequired,
+    UsernameRequired,
+    PasswordRequired,
+    InvalidPort,
+    InvalidTimeout,
+    InvalidApplicationName,
 }
 
 impl SqlServerConnectionConfig {
+    pub fn validate(&self) -> Result<(), Vec<ConnectionConfigValidationError>> {
+        let mut errors = Vec::new();
+
+        if self.host.trim().is_empty() {
+            errors.push(ConnectionConfigValidationError::HostRequired);
+        }
+
+        if self.database.trim().is_empty() {
+            errors.push(ConnectionConfigValidationError::DatabaseRequired);
+        }
+
+        if self.username.trim().is_empty() {
+            errors.push(ConnectionConfigValidationError::UsernameRequired);
+        }
+
+        if self.password.trim().is_empty() {
+            errors.push(ConnectionConfigValidationError::PasswordRequired);
+        }
+
+        if self.port == 0 {
+            errors.push(ConnectionConfigValidationError::InvalidPort);
+        }
+
+        if self.connection_timeout_seconds == 0
+            || self.connection_timeout_seconds > MAX_TIMEOUT_SECONDS
+        {
+            errors.push(ConnectionConfigValidationError::InvalidTimeout);
+        }
+
+        if let Some(application_name) = &self.application_name {
+            if application_name.trim().is_empty() {
+                errors.push(ConnectionConfigValidationError::InvalidApplicationName);
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
     pub fn from_connection_string(connection_string: &str) -> RepositoryResult<Self> {
-        let mut host = None;
-        let mut port = 1433u16;
-        let mut username = None;
-        let mut password = None;
-        let mut database = None;
-        let mut trust_cert = false;
+        let mut config = Self::default();
 
         for token in connection_string
             .split(';')
@@ -35,39 +128,45 @@ impl SqlServerConnectionConfig {
             match key.as_str() {
                 "server" | "data source" => {
                     let mut host_parts = value.split(',');
-                    host = host_parts
-                        .next()
-                        .map(str::trim)
-                        .filter(|item| !item.is_empty())
-                        .map(str::to_owned);
+                    config.host = host_parts.next().unwrap_or_default().trim().to_owned();
                     if let Some(parsed_port) = host_parts
                         .next()
                         .and_then(|item| item.trim().parse::<u16>().ok())
                     {
-                        port = parsed_port;
+                        config.port = parsed_port;
                     }
                 }
-                "user id" | "uid" | "user" => {
-                    username = (!value.is_empty()).then(|| value.to_owned())
-                }
-                "password" | "pwd" => password = (!value.is_empty()).then(|| value.to_owned()),
-                "database" | "initial catalog" => {
-                    database = (!value.is_empty()).then(|| value.to_owned())
-                }
+                "user id" | "uid" | "user" => config.username = value.to_owned(),
+                "password" | "pwd" => config.password = value.to_owned(),
+                "database" | "initial catalog" => config.database = value.to_owned(),
                 "trustservercertificate" => {
-                    trust_cert = matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes")
+                    config.trust_server_certificate =
+                        matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes")
+                }
+                "encrypt" => {
+                    config.encrypt =
+                        !matches!(value.to_ascii_lowercase().as_str(), "false" | "0" | "no")
+                }
+                "connection timeout" | "connect timeout" => {
+                    if let Ok(parsed_timeout) = value.parse::<u64>() {
+                        config.connection_timeout_seconds = parsed_timeout;
+                    }
+                }
+                "application name" => {
+                    config.application_name = if value.is_empty() {
+                        None
+                    } else {
+                        Some(value.to_owned())
+                    }
                 }
                 _ => {}
             }
         }
 
-        Ok(Self {
-            host: host.ok_or(RepositoryError::InvalidConfiguration("missing host"))?,
-            port,
-            username: username.ok_or(RepositoryError::InvalidConfiguration("missing username"))?,
-            password: password.ok_or(RepositoryError::InvalidConfiguration("missing password"))?,
-            database: database.ok_or(RepositoryError::InvalidConfiguration("missing database"))?,
-            trust_cert,
-        })
+        config.validate().map_err(|_| {
+            RepositoryError::InvalidConfiguration("invalid SQL Server connection configuration")
+        })?;
+
+        Ok(config)
     }
 }

--- a/crates/sql-intelliscan-repository/src/sql_server/connection_repository.rs
+++ b/crates/sql-intelliscan-repository/src/sql_server/connection_repository.rs
@@ -68,7 +68,7 @@ impl SqlServerConnectionRepository {
             &self.config.username,
             &self.config.password,
             &self.config.database,
-            self.config.trust_cert,
+            self.config.trust_server_certificate,
         )
     }
 
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(config.username, "sa");
         assert_eq!(config.password, "secret");
         assert_eq!(config.database, "master");
-        assert!(config.trust_cert);
+        assert!(config.trust_server_certificate);
     }
 
     #[test]

--- a/crates/sql-intelliscan-repository/tests/repository.rs
+++ b/crates/sql-intelliscan-repository/tests/repository.rs
@@ -28,6 +28,8 @@ fn GivenConnectionStringWithoutCredentials_WhenParsed_ThenResult_ShouldReturnInv
 
     assert_eq!(
         result,
-        Err(RepositoryError::InvalidConfiguration("invalid SQL Server connection configuration"))
+        Err(RepositoryError::InvalidConfiguration(
+            "invalid SQL Server connection configuration"
+        ))
     );
 }

--- a/crates/sql-intelliscan-repository/tests/repository.rs
+++ b/crates/sql-intelliscan-repository/tests/repository.rs
@@ -28,8 +28,6 @@ fn GivenConnectionStringWithoutCredentials_WhenParsed_ThenResult_ShouldReturnInv
 
     assert_eq!(
         result,
-        Err(RepositoryError::InvalidConfiguration(
-            "invalid SQL Server connection configuration"
-        ))
+        Err(RepositoryError::InvalidConfiguration("missing username"))
     );
 }

--- a/crates/sql-intelliscan-repository/tests/repository.rs
+++ b/crates/sql-intelliscan-repository/tests/repository.rs
@@ -28,6 +28,6 @@ fn GivenConnectionStringWithoutCredentials_WhenParsed_ThenResult_ShouldReturnInv
 
     assert_eq!(
         result,
-        Err(RepositoryError::InvalidConfiguration("missing username"))
+        Err(RepositoryError::InvalidConfiguration("invalid SQL Server connection configuration"))
     );
 }

--- a/crates/sql-intelliscan-repository/tests/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/tests/sql_server_connection_config.rs
@@ -1,6 +1,8 @@
 #![allow(non_snake_case)]
 
-use sql_intelliscan_repository::{ConnectionConfigValidationError, SqlServerConnectionConfig};
+use sql_intelliscan_repository::{
+    ConnectionConfigValidationError, RepositoryError, SqlServerConnectionConfig,
+};
 
 #[test]
 fn GivenValidConfiguration_WhenValidated_ThenResult_ShouldReturnOk() {
@@ -90,4 +92,28 @@ fn GivenSensitivePassword_WhenDebugFormatted_ThenOutput_ShouldMaskSecret() {
 
     assert!(!debug_output.contains("super-secret"));
     assert!(debug_output.contains("\"***\""));
+}
+
+#[test]
+fn GivenConnectionStringWithoutServer_WhenParsed_ThenResult_ShouldReturnMissingHost() {
+    let result = SqlServerConnectionConfig::from_connection_string(
+        "User Id=sa;Password=secret;Database=master;",
+    );
+
+    assert_eq!(
+        result,
+        Err(RepositoryError::InvalidConfiguration("missing host"))
+    );
+}
+
+#[test]
+fn GivenConnectionStringWithoutDatabase_WhenParsed_ThenResult_ShouldReturnMissingDatabase() {
+    let result = SqlServerConnectionConfig::from_connection_string(
+        "Server=localhost;User Id=sa;Password=secret;",
+    );
+
+    assert_eq!(
+        result,
+        Err(RepositoryError::InvalidConfiguration("missing database"))
+    );
 }

--- a/crates/sql-intelliscan-repository/tests/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/tests/sql_server_connection_config.rs
@@ -95,6 +95,35 @@ fn GivenSensitivePassword_WhenDebugFormatted_ThenOutput_ShouldMaskSecret() {
 }
 
 #[test]
+fn GivenValidConnectionString_WhenParsed_ThenConfig_ShouldPopulateCoreFields() {
+    let config = SqlServerConnectionConfig::from_connection_string(
+        "Server=sql.example.test,1444;User Id=sa;Password=secret;Database=warehouse;TrustServerCertificate=yes;",
+    )
+    .expect("connection string should parse");
+
+    assert_eq!(config.host, "sql.example.test");
+    assert_eq!(config.port, 1444);
+    assert_eq!(config.username, "sa");
+    assert_eq!(config.password, "secret");
+    assert_eq!(config.database, "warehouse");
+    assert!(config.trust_server_certificate);
+}
+
+#[test]
+fn GivenConnectionStringWithMalformedSegment_WhenParsed_ThenResult_ShouldReturnInvalidSegment() {
+    let result = SqlServerConnectionConfig::from_connection_string(
+        "Server=localhost;MalformedSegment;User Id=sa;Password=secret;Database=master;",
+    );
+
+    assert_eq!(
+        result,
+        Err(RepositoryError::InvalidConfiguration(
+            "invalid connection string segment"
+        ))
+    );
+}
+
+#[test]
 fn GivenConnectionStringWithoutServer_WhenParsed_ThenResult_ShouldReturnMissingHost() {
     let result = SqlServerConnectionConfig::from_connection_string(
         "User Id=sa;Password=secret;Database=master;",
@@ -115,5 +144,17 @@ fn GivenConnectionStringWithoutDatabase_WhenParsed_ThenResult_ShouldReturnMissin
     assert_eq!(
         result,
         Err(RepositoryError::InvalidConfiguration("missing database"))
+    );
+}
+
+#[test]
+fn GivenConnectionStringWithInvalidServerPort_WhenParsed_ThenResult_ShouldReturnInvalidPort() {
+    let result = SqlServerConnectionConfig::from_connection_string(
+        "Server=localhost,not-a-number;User Id=sa;Password=secret;Database=master;",
+    );
+
+    assert_eq!(
+        result,
+        Err(RepositoryError::InvalidConfiguration("invalid port"))
     );
 }

--- a/crates/sql-intelliscan-repository/tests/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/tests/sql_server_connection_config.rs
@@ -158,3 +158,66 @@ fn GivenConnectionStringWithInvalidServerPort_WhenParsed_ThenResult_ShouldReturn
         Err(RepositoryError::InvalidConfiguration("invalid port"))
     );
 }
+
+#[test]
+fn GivenConnectionStringWithExtendedOptions_WhenParsed_ThenConfig_ShouldPopulateOptions() {
+    let config = SqlServerConnectionConfig::from_connection_string(
+        "Server=localhost;User Id=sa;Password=secret;Database=master;Encrypt=no;Connection Timeout=45;Application Name=Sql Intelliscan Tests;",
+    )
+    .expect("connection string should parse");
+
+    assert!(!config.encrypt);
+    assert_eq!(config.connection_timeout_seconds, 45);
+    assert_eq!(
+        config.application_name,
+        Some("Sql Intelliscan Tests".to_owned())
+    );
+}
+
+#[test]
+fn GivenConnectionStringWithWhitespaceAroundExtendedOptions_WhenParsed_ThenConfig_ShouldTrimValues()
+{
+    let config = SqlServerConnectionConfig::from_connection_string(
+        "Server=localhost;User Id=sa;Password=secret;Database=master; Encrypt = false ; Connect Timeout = 60 ; Application Name = Reporting Worker ;",
+    )
+    .expect("connection string should parse");
+
+    assert!(!config.encrypt);
+    assert_eq!(config.connection_timeout_seconds, 60);
+    assert_eq!(config.application_name, Some("Reporting Worker".to_owned()));
+}
+
+#[test]
+fn GivenConnectionStringWithBlankApplicationName_WhenParsed_ThenConfig_ShouldUseNoApplicationName()
+{
+    let config = SqlServerConnectionConfig::from_connection_string(
+        "Server=localhost;User Id=sa;Password=secret;Database=master;Application Name=   ;",
+    )
+    .expect("connection string should parse");
+
+    assert_eq!(config.application_name, None);
+}
+
+#[test]
+fn GivenConnectionStringWithInvalidEncrypt_WhenParsed_ThenResult_ShouldReturnInvalidEncrypt() {
+    let result = SqlServerConnectionConfig::from_connection_string(
+        "Server=localhost;User Id=sa;Password=secret;Database=master;Encrypt=maybe;",
+    );
+
+    assert_eq!(
+        result,
+        Err(RepositoryError::InvalidConfiguration("invalid encrypt"))
+    );
+}
+
+#[test]
+fn GivenConnectionStringWithInvalidTimeout_WhenParsed_ThenResult_ShouldReturnInvalidTimeout() {
+    let result = SqlServerConnectionConfig::from_connection_string(
+        "Server=localhost;User Id=sa;Password=secret;Database=master;Connection Timeout=soon;",
+    );
+
+    assert_eq!(
+        result,
+        Err(RepositoryError::InvalidConfiguration("invalid timeout"))
+    );
+}

--- a/crates/sql-intelliscan-repository/tests/sql_server_connection_config.rs
+++ b/crates/sql-intelliscan-repository/tests/sql_server_connection_config.rs
@@ -1,66 +1,93 @@
 #![allow(non_snake_case)]
 
-use sql_intelliscan_repository::{RepositoryError, SqlServerConnectionConfig};
+use sql_intelliscan_repository::{ConnectionConfigValidationError, SqlServerConnectionConfig};
 
 #[test]
-fn GivenConnectionStringWithMalformedSegment_WhenParsed_ThenResult_ShouldReturnInvalidConfiguration(
-) {
-    let result = SqlServerConnectionConfig::from_connection_string(
-        "Server=localhost;MalformedSegment;User Id=sa;Password=secret;Database=master;",
-    );
+fn GivenValidConfiguration_WhenValidated_ThenResult_ShouldReturnOk() {
+    let config = SqlServerConnectionConfig {
+        host: "localhost".to_owned(),
+        port: 1433,
+        database: "master".to_owned(),
+        username: "sa".to_owned(),
+        password: "StrongPassword123".to_owned(),
+        encrypt: true,
+        trust_server_certificate: true,
+        connection_timeout_seconds: 30,
+        application_name: Some("SQL Intelliscan".to_owned()),
+    };
 
-    assert_eq!(
-        result,
-        Err(RepositoryError::InvalidConfiguration(
-            "invalid connection string segment"
-        ))
-    );
+    assert!(config.validate().is_ok());
 }
 
 #[test]
-fn GivenConnectionStringWithEmptyServer_WhenParsed_ThenResult_ShouldReturnMissingHost() {
-    let result = SqlServerConnectionConfig::from_connection_string(
-        "Server=   ;User Id=sa;Password=secret;Database=master;",
-    );
+fn GivenMissingRequiredFields_WhenValidated_ThenResult_ShouldReturnAllErrors() {
+    let config = SqlServerConnectionConfig {
+        host: "   ".to_owned(),
+        port: 1433,
+        database: "".to_owned(),
+        username: " ".to_owned(),
+        password: "".to_owned(),
+        encrypt: true,
+        trust_server_certificate: false,
+        connection_timeout_seconds: 30,
+        application_name: Some("SQL Intelliscan".to_owned()),
+    };
 
-    assert_eq!(
-        result,
-        Err(RepositoryError::InvalidConfiguration("missing host"))
-    );
+    let result = config.validate();
+
+    assert!(result.is_err());
+    let errors = result.expect_err("expected validation errors");
+    assert!(errors.contains(&ConnectionConfigValidationError::HostRequired));
+    assert!(errors.contains(&ConnectionConfigValidationError::DatabaseRequired));
+    assert!(errors.contains(&ConnectionConfigValidationError::UsernameRequired));
+    assert!(errors.contains(&ConnectionConfigValidationError::PasswordRequired));
 }
 
 #[test]
-fn GivenConnectionStringWithEmptyUsername_WhenParsed_ThenResult_ShouldReturnMissingUsername() {
-    let result = SqlServerConnectionConfig::from_connection_string(
-        "Server=localhost;User Id=   ;Password=secret;Database=master;",
-    );
+fn GivenInvalidPort_WhenValidated_ThenResult_ShouldReturnInvalidPortError() {
+    let config = SqlServerConnectionConfig {
+        port: 0,
+        ..SqlServerConnectionConfig::default()
+    };
 
-    assert_eq!(
-        result,
-        Err(RepositoryError::InvalidConfiguration("missing username"))
-    );
+    let errors = config.validate().expect_err("expected invalid port error");
+
+    assert!(errors.contains(&ConnectionConfigValidationError::InvalidPort));
 }
 
 #[test]
-fn GivenConnectionStringWithEmptyPassword_WhenParsed_ThenResult_ShouldReturnMissingPassword() {
-    let result = SqlServerConnectionConfig::from_connection_string(
-        "Server=localhost;User Id=sa;Password=   ;Database=master;",
-    );
+fn GivenInvalidTimeoutValues_WhenValidated_ThenResult_ShouldReturnInvalidTimeoutError() {
+    let zero_timeout_config = SqlServerConnectionConfig {
+        connection_timeout_seconds: 0,
+        ..SqlServerConnectionConfig::default()
+    };
 
-    assert_eq!(
-        result,
-        Err(RepositoryError::InvalidConfiguration("missing password"))
-    );
+    let high_timeout_config = SqlServerConnectionConfig {
+        connection_timeout_seconds: 301,
+        ..SqlServerConnectionConfig::default()
+    };
+
+    assert!(zero_timeout_config
+        .validate()
+        .expect_err("expected timeout validation error")
+        .contains(&ConnectionConfigValidationError::InvalidTimeout));
+
+    assert!(high_timeout_config
+        .validate()
+        .expect_err("expected timeout validation error")
+        .contains(&ConnectionConfigValidationError::InvalidTimeout));
 }
 
 #[test]
-fn GivenConnectionStringWithEmptyDatabase_WhenParsed_ThenResult_ShouldReturnMissingDatabase() {
-    let result = SqlServerConnectionConfig::from_connection_string(
-        "Server=localhost;User Id=sa;Password=secret;Database=   ;",
-    );
+fn GivenSensitivePassword_WhenDebugFormatted_ThenOutput_ShouldMaskSecret() {
+    let config = SqlServerConnectionConfig {
+        username: "sa".to_owned(),
+        password: "super-secret".to_owned(),
+        ..SqlServerConnectionConfig::default()
+    };
 
-    assert_eq!(
-        result,
-        Err(RepositoryError::InvalidConfiguration("missing database"))
-    );
+    let debug_output = format!("{:?}", config);
+
+    assert!(!debug_output.contains("super-secret"));
+    assert!(debug_output.contains("\"***\""));
 }


### PR DESCRIPTION
### Motivation
- Provide a strongly typed, driver-agnostic SQL Server connection configuration model to avoid hardcoded connection strings and establish a clear contract between `tauri-src` and the `repository` layer.
- Ensure sensitive fields are handled safely by preventing secrets from leaking in logs or debug output and by centralizing validation rules.

### Description
- Added `SqlServerConnectionConfig` with fields `host`, `port`, `database`, `username`, `password`, `encrypt`, `trust_server_certificate`, `connection_timeout_seconds`, and `application_name` and implemented `Default` with secure defaults.
- Implemented `ConnectionConfigValidationError` enum and a `validate()` method to enforce required fields, valid port and timeout ranges, and non-empty trimmed `application_name`.
- Added a custom `Debug` impl that masks the `password` field to prevent secret exposure and updated `from_connection_string` to populate the model and run validation before returning.
- Exported `ConnectionConfigValidationError` from the repository crate, updated the SQL Server repository to use the new `trust_server_certificate` field, and added/updated unit tests covering valid config, missing required fields, invalid port/timeout values, and password masking.

### Testing
- Ran `cargo fmt --all` and formatting succeeded.
- Ran `cargo test -p sql-intelliscan-repository` and all repository unit tests passed (integration tests that require a real SQL Server were ignored as expected).
- Ran `cargo clippy -p sql-intelliscan-repository --all-targets -- -D warnings` with no warnings.
- Generated coverage with `cargo llvm-cov -p sql-intelliscan-repository` and verified coverage using `python3 ./scripts/check-coverage.py`, producing repository line coverage of `88.06%` which meets the ≥80% requirement.

Close #36 
------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c0854e708320ac207b9eabd26c84)