### PR TITLE
Document mssqlrust repository boundary

### DIFF
--- a/crates/sql-intelliscan-repository/src/sql_server/mod.rs
+++ b/crates/sql-intelliscan-repository/src/sql_server/mod.rs
@@ -1,3 +1,9 @@
+//! SQL Server repository implementations.
+//!
+//! This module is the only backend boundary that may depend on `mssqlrust`.
+//! Upper layers must stay driver-agnostic and interact with SQL Server behavior
+//! through repository contracts instead of importing driver types directly.
+
 mod connection_repository;
 mod metadata_repository;
 


### PR DESCRIPTION
## Summary

- Document the SQL Server repository module as the only backend boundary allowed to depend on `mssqlrust`.
- Clarify that upper layers must stay driver-agnostic and use repository contracts instead of importing driver types directly.

## Issue

Closes #39.

## Validation

- `cargo fmt --check`
- `cargo check -p sql-intelliscan-repository`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets`
- `CARGO_TARGET_DIR=/tmp/sql-intelliscan-target cargo test --workspace --no-run`
- `CARGO_TARGET_DIR=/tmp/sql-intelliscan-target cargo test --workspace`
- `CARGO_TARGET_DIR=/tmp/sql-intelliscan-target cargo test -p sql-intelliscan-common`
- `CARGO_TARGET_DIR=/tmp/sql-intelliscan-target cargo test -p sql-intelliscan-repository`
- `CARGO_TARGET_DIR=/tmp/sql-intelliscan-target cargo test -p sql-intelliscan-services`
- `CARGO_TARGET_DIR=/tmp/sql-intelliscan-wasm-target bash ./scripts/wasm-test-local.sh`
- Frontend coverage: 95.83%
- Backend coverage: 93.84%
- Common crate coverage: 100.00%
- Repository crate coverage: 91.38%
- Services crate coverage: 100.00%

