### PR TITLE
US-002.6: Use AppState services in Tauri commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 leptos = { version = "0.8.19", features = ["ssr"] }
 sql_intelliscan_lib = { path = "src-tauri", package = "sql-intelliscan" }
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["test"] }
 
 [workspace]
 members = [

--- a/src-tauri/src/commands/connection_commands.rs
+++ b/src-tauri/src/commands/connection_commands.rs
@@ -1,12 +1,18 @@
+use serde::Deserialize;
 use sql_intelliscan_services::models::ConnectionTestResult;
 
 use crate::{AppState, CommandErrorResponse, CommandSuccessResponse};
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ValidateConnectionRequest {
+    pub connection_string: String,
+}
+
 pub async fn validate_sql_server_connection_command(
     state: tauri::State<'_, AppState>,
-    connection_string: String,
+    request: ValidateConnectionRequest,
 ) -> Result<CommandSuccessResponse<ConnectionTestResult>, CommandErrorResponse> {
-    validate_sql_server_connection_with_state(state.inner(), &connection_string)
+    validate_sql_server_connection_with_state(state.inner(), &request.connection_string)
         .await
         .map(|result| CommandSuccessResponse {
             message: "Connection validated successfully".to_string(),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ mod response_models;
 
 use tauri::State;
 
+pub use connection_commands::ValidateConnectionRequest;
 pub use response_models::{CommandErrorResponse, CommandSuccessResponse};
 use sql_intelliscan_services::models::ConnectionTestResult;
 
@@ -17,9 +18,9 @@ pub fn greet_command(state: State<'_, AppState>, name: &str) -> CommandSuccessRe
 #[tauri::command]
 pub async fn validate_sql_server_connection_command(
     state: State<'_, AppState>,
-    connection_string: String,
+    request: ValidateConnectionRequest,
 ) -> Result<CommandSuccessResponse<ConnectionTestResult>, CommandErrorResponse> {
-    connection_commands::validate_sql_server_connection_command(state, connection_string).await
+    connection_commands::validate_sql_server_connection_command(state, request).await
 }
 
 pub fn greet_with_state(state: &AppState, name: &str) -> String {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod state;
 pub use commands::{
     greet_command, greet_with_state, register_handlers, validate_sql_server_connection_command,
     validate_sql_server_connection_with_state, CommandErrorResponse, CommandSuccessResponse,
+    ValidateConnectionRequest,
 };
 use configuration::run_builder;
 pub use configuration::{build_app, try_build_app};
@@ -13,8 +14,9 @@ pub use dependency_wiring::{
     build_app_state, greet_user, shared_app_state, validate_sql_server_connection,
 };
 pub use sql_intelliscan_services::errors::ServiceError;
-pub use state::AppState;
+pub use sql_intelliscan_services::models;
 use state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};
+pub use state::{AppState, ConnectionServicePort, GreetingServicePort};
 
 const DEFAULT_BUILDER_FACTORY: BuilderFactory = build_app;
 const DEFAULT_RUNNER: Runner = run_builder;

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use sql_intelliscan_services::{
-    errors::{ServiceError, ServiceResult},
+    errors::ServiceResult,
     models::ConnectionTestResult,
     repository_wiring::{BackendMetadataRepositoryAdapter, SqlServerConnectionRepositoryFactory},
     ConnectionService, GreetingService,
@@ -11,17 +11,17 @@ pub(crate) type AppGreetingService = GreetingService<BackendMetadataRepositoryAd
 pub(crate) type AppConnectionService = ConnectionService<SqlServerConnectionRepositoryFactory>;
 
 type ConnectionValidationFuture<'a> =
-    Pin<Box<dyn Future<Output = Result<ConnectionTestResult, ServiceError>> + Send + 'a>>;
+    Pin<Box<dyn Future<Output = ServiceResult<ConnectionTestResult>> + Send + 'a>>;
 
 pub trait GreetingServicePort: Send + Sync {
     fn greet(&self, name: &str) -> String;
 }
 
 pub trait ConnectionServicePort: Send + Sync {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        connection_string: &'a str,
-    ) -> ConnectionValidationFuture<'a>;
+    fn validate_sql_server_connection(
+        &self,
+        connection_string: &str,
+    ) -> ConnectionValidationFuture<'_>;
 }
 
 impl GreetingServicePort for AppGreetingService {
@@ -31,11 +31,12 @@ impl GreetingServicePort for AppGreetingService {
 }
 
 impl ConnectionServicePort for AppConnectionService {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        connection_string: &'a str,
-    ) -> ConnectionValidationFuture<'a> {
-        Box::pin(async move { self.test_configured_connection(connection_string).await })
+    fn validate_sql_server_connection(
+        &self,
+        connection_string: &str,
+    ) -> ConnectionValidationFuture<'_> {
+        let connection_string = connection_string.to_string();
+        Box::pin(async move { self.test_configured_connection(&connection_string).await })
     }
 }
 
@@ -63,7 +64,7 @@ impl AppState {
     pub async fn validate_sql_server_connection(
         &self,
         connection_string: &str,
-    ) -> Result<ConnectionTestResult, ServiceError> {
+    ) -> ServiceResult<ConnectionTestResult> {
         self.connection_service
             .validate_sql_server_connection(connection_string)
             .await

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use sql_intelliscan_services::{
     errors::{ServiceError, ServiceResult},
@@ -10,16 +10,45 @@ use sql_intelliscan_services::{
 pub(crate) type AppGreetingService = GreetingService<BackendMetadataRepositoryAdapter>;
 pub(crate) type AppConnectionService = ConnectionService<SqlServerConnectionRepositoryFactory>;
 
+type ConnectionValidationFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<ConnectionTestResult, ServiceError>> + Send + 'a>>;
+
+pub trait GreetingServicePort: Send + Sync {
+    fn greet(&self, name: &str) -> String;
+}
+
+pub trait ConnectionServicePort: Send + Sync {
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        connection_string: &'a str,
+    ) -> ConnectionValidationFuture<'a>;
+}
+
+impl GreetingServicePort for AppGreetingService {
+    fn greet(&self, name: &str) -> String {
+        GreetingService::greet(self, name)
+    }
+}
+
+impl ConnectionServicePort for AppConnectionService {
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        connection_string: &'a str,
+    ) -> ConnectionValidationFuture<'a> {
+        Box::pin(async move { self.test_configured_connection(connection_string).await })
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
-    greeting_service: Arc<AppGreetingService>,
-    connection_service: Arc<AppConnectionService>,
+    greeting_service: Arc<dyn GreetingServicePort>,
+    connection_service: Arc<dyn ConnectionServicePort>,
 }
 
 impl AppState {
-    pub(crate) fn new(
-        greeting_service: Arc<AppGreetingService>,
-        connection_service: Arc<AppConnectionService>,
+    pub fn new(
+        greeting_service: Arc<dyn GreetingServicePort>,
+        connection_service: Arc<dyn ConnectionServicePort>,
     ) -> Self {
         Self {
             greeting_service,
@@ -36,7 +65,7 @@ impl AppState {
         connection_string: &str,
     ) -> Result<ConnectionTestResult, ServiceError> {
         self.connection_service
-            .test_configured_connection(connection_string)
+            .validate_sql_server_connection(connection_string)
             .await
     }
 }

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -1,5 +1,5 @@
 mod app_state;
 mod runtime_state;
 
-pub use app_state::{AppState, AppStateResult};
+pub use app_state::{AppState, AppStateResult, ConnectionServicePort, GreetingServicePort};
 pub(crate) use runtime_state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -1,9 +1,12 @@
 #![allow(non_snake_case)]
 
+use std::{future::Future, pin::Pin, sync::Arc};
+
 use sql_intelliscan_lib::{
     build_app_state, greet_command, greet_with_state, register_handlers,
-    validate_sql_server_connection_command, validate_sql_server_connection_with_state,
-    CommandErrorResponse,
+    validate_sql_server_connection_command, validate_sql_server_connection_with_state, AppState,
+    CommandErrorResponse, ConnectionServicePort, GreetingServicePort, ServiceError,
+    ValidateConnectionRequest,
 };
 use tauri::Manager;
 
@@ -67,7 +70,9 @@ fn GivenManagedStateAndInvalidConnectionString_WhenValidateCommandIsCalled_ThenR
 
     let result = tauri::async_runtime::block_on(validate_sql_server_connection_command(
         app.state(),
-        "Server=localhost;Database=master".to_string(),
+        ValidateConnectionRequest {
+            connection_string: "Server=localhost;Database=master".to_string(),
+        },
     ));
 
     let error = result.expect_err("expected invalid configuration error");
@@ -75,4 +80,41 @@ fn GivenManagedStateAndInvalidConnectionString_WhenValidateCommandIsCalled_ThenR
         error.message,
         "The provided configuration is invalid: missing username."
     );
+}
+
+struct MockGreetingService;
+impl GreetingServicePort for MockGreetingService {
+    fn greet(&self, name: &str) -> String {
+        format!("mock-{name}")
+    }
+}
+
+struct MockConnectionService;
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+impl ConnectionServicePort for MockConnectionService {
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        _connection_string: &'a str,
+    ) -> BoxFuture<'a, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
+        Box::pin(async { Err(ServiceError::SourceUnavailable) })
+    }
+}
+
+#[test]
+fn GivenMockedServices_WhenValidateCommandRuns_ThenCommand_ShouldDelegateAndMapError() {
+    let app_state = AppState::new(Arc::new(MockGreetingService), Arc::new(MockConnectionService));
+    let app = tauri::test::mock_builder()
+        .manage(app_state)
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("mock app should build");
+
+    let result = tauri::async_runtime::block_on(validate_sql_server_connection_command(
+        app.state(),
+        ValidateConnectionRequest {
+            connection_string: "ignored".to_string(),
+        },
+    ));
+
+    let error = result.expect_err("expected service error");
+    assert_eq!(error.message, "The data source is currently unavailable.");
 }

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -92,10 +92,10 @@ impl GreetingServicePort for MockGreetingService {
 struct MockConnectionService;
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 impl ConnectionServicePort for MockConnectionService {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        _connection_string: &'a str,
-    ) -> BoxFuture<'a, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
+    fn validate_sql_server_connection(
+        &self,
+        _connection_string: &str,
+    ) -> BoxFuture<'_, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
         Box::pin(async { Err(ServiceError::SourceUnavailable) })
     }
 }


### PR DESCRIPTION
### Motivation
- Implementar US-002.6 para que los comandos Tauri sean delgados y deleguen la lógica de negocio en el crate `services` mediante `AppState`.
- Mejorar desacoplamiento y testabilidad exponiendo puertos de servicio (traits) en `AppState` y evitando que los comandos instancien repositorios o contengan SQL/ reglas de negocio.
- Asegurar que los comandos solo transformen IO y mapeen errores a respuestas amigables, y que las pruebas sigan las reglas definidas en `agents.md` y la configuración de CI.

### Description
- Introduce el DTO `ValidateConnectionRequest` y adapta `validate_sql_server_connection_command` para recibir `State<AppState>` y `ValidateConnectionRequest` y delegar la ejecución al servicio correspondiente.
- Refactoriza `AppState` para usar trait-objects `GreetingServicePort` y `ConnectionServicePort`, con adaptadores que implementan los puertos para las implementaciones concretas de `sql_intelliscan_services`.
- Actualiza los módulos y reexportaciones (`src-tauri/src/lib.rs`, `src-tauri/src/commands/mod.rs`, `src-tauri/src/state/mod.rs`) para exponer los nuevos tipos y facilitar pruebas y wiring.
- Añade/actualiza pruebas backend en `tests/backend/commands.rs` que usan `tauri::test::mock_builder()` y servicios mockeados para verificar delegación y mapeo de errores user-friendly.

### Testing
- Ejecutado `cargo fmt --all` y `cargo clippy --workspace --all-targets -- -D warnings`, ambos completaron correctamente.
- Ejecutado `cargo test --workspace --no-run` para validar la compilación del workspace y las pruebas; la compilación de crates finalizó correctamente en la fase de build (las pruebas se mantienen conforme al flujo CI por el tamaño de las dependencias Tauri/WebKit en este entorno).
- Revisado el flujo de CI `.github/workflows/buildtest.yml` y `agents.md` para asegurar que los nuevos/ modificados tests están en `tests/backend` y usan mocks según las reglas de pruebas y cobertura definidas (backend mínimo 80%).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64a9a80e883208b5c248c4a950e9f)