### PR TITLE
# 🧩 US-003.5 – Implement Service-Level Connection Validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 leptos = { version = "0.8.19", features = ["ssr"] }
 sql_intelliscan_lib = { path = "src-tauri", package = "sql-intelliscan" }
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["test"] }
 
 [workspace]
 members = [

--- a/src-tauri/src/commands/connection_commands.rs
+++ b/src-tauri/src/commands/connection_commands.rs
@@ -1,12 +1,18 @@
+use serde::Deserialize;
 use sql_intelliscan_services::models::ConnectionTestResult;
 
 use crate::{AppState, CommandErrorResponse, CommandSuccessResponse};
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ValidateConnectionRequest {
+    pub connection_string: String,
+}
+
 pub async fn validate_sql_server_connection_command(
     state: tauri::State<'_, AppState>,
-    connection_string: String,
+    request: ValidateConnectionRequest,
 ) -> Result<CommandSuccessResponse<ConnectionTestResult>, CommandErrorResponse> {
-    validate_sql_server_connection_with_state(state.inner(), &connection_string)
+    validate_sql_server_connection_with_state(state.inner(), &request.connection_string)
         .await
         .map(|result| CommandSuccessResponse {
             message: "Connection validated successfully".to_string(),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ mod response_models;
 
 use tauri::State;
 
+pub use connection_commands::ValidateConnectionRequest;
 pub use response_models::{CommandErrorResponse, CommandSuccessResponse};
 use sql_intelliscan_services::models::ConnectionTestResult;
 
@@ -17,9 +18,9 @@ pub fn greet_command(state: State<'_, AppState>, name: &str) -> CommandSuccessRe
 #[tauri::command]
 pub async fn validate_sql_server_connection_command(
     state: State<'_, AppState>,
-    connection_string: String,
+    request: ValidateConnectionRequest,
 ) -> Result<CommandSuccessResponse<ConnectionTestResult>, CommandErrorResponse> {
-    connection_commands::validate_sql_server_connection_command(state, connection_string).await
+    connection_commands::validate_sql_server_connection_command(state, request).await
 }
 
 pub fn greet_with_state(state: &AppState, name: &str) -> String {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod state;
 pub use commands::{
     greet_command, greet_with_state, register_handlers, validate_sql_server_connection_command,
     validate_sql_server_connection_with_state, CommandErrorResponse, CommandSuccessResponse,
+    ValidateConnectionRequest,
 };
 use configuration::run_builder;
 pub use configuration::{build_app, try_build_app};
@@ -13,8 +14,9 @@ pub use dependency_wiring::{
     build_app_state, greet_user, shared_app_state, validate_sql_server_connection,
 };
 pub use sql_intelliscan_services::errors::ServiceError;
-pub use state::AppState;
+pub use sql_intelliscan_services::models;
 use state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};
+pub use state::{AppState, ConnectionServicePort, GreetingServicePort};
 
 const DEFAULT_BUILDER_FACTORY: BuilderFactory = build_app;
 const DEFAULT_RUNNER: Runner = run_builder;

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use sql_intelliscan_services::{
-    errors::{ServiceError, ServiceResult},
+    errors::ServiceResult,
     models::ConnectionTestResult,
     repository_wiring::{BackendMetadataRepositoryAdapter, SqlServerConnectionRepositoryFactory},
     ConnectionService, GreetingService,
@@ -11,17 +11,17 @@ pub(crate) type AppGreetingService = GreetingService<BackendMetadataRepositoryAd
 pub(crate) type AppConnectionService = ConnectionService<SqlServerConnectionRepositoryFactory>;
 
 type ConnectionValidationFuture<'a> =
-    Pin<Box<dyn Future<Output = Result<ConnectionTestResult, ServiceError>> + Send + 'a>>;
+    Pin<Box<dyn Future<Output = ServiceResult<ConnectionTestResult>> + Send + 'a>>;
 
 pub trait GreetingServicePort: Send + Sync {
     fn greet(&self, name: &str) -> String;
 }
 
 pub trait ConnectionServicePort: Send + Sync {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        connection_string: &'a str,
-    ) -> ConnectionValidationFuture<'a>;
+    fn validate_sql_server_connection(
+        &self,
+        connection_string: &str,
+    ) -> ConnectionValidationFuture<'_>;
 }
 
 impl GreetingServicePort for AppGreetingService {
@@ -31,11 +31,12 @@ impl GreetingServicePort for AppGreetingService {
 }
 
 impl ConnectionServicePort for AppConnectionService {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        connection_string: &'a str,
-    ) -> ConnectionValidationFuture<'a> {
-        Box::pin(async move { self.test_configured_connection(connection_string).await })
+    fn validate_sql_server_connection(
+        &self,
+        connection_string: &str,
+    ) -> ConnectionValidationFuture<'_> {
+        let connection_string = connection_string.to_string();
+        Box::pin(async move { self.test_configured_connection(&connection_string).await })
     }
 }
 
@@ -63,7 +64,7 @@ impl AppState {
     pub async fn validate_sql_server_connection(
         &self,
         connection_string: &str,
-    ) -> Result<ConnectionTestResult, ServiceError> {
+    ) -> ServiceResult<ConnectionTestResult> {
         self.connection_service
             .validate_sql_server_connection(connection_string)
             .await

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -18,10 +18,10 @@ pub trait GreetingServicePort: Send + Sync {
 }
 
 pub trait ConnectionServicePort: Send + Sync {
-    fn validate_sql_server_connection(
-        &self,
-        connection_string: &str,
-    ) -> ConnectionValidationFuture<'_>;
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        connection_string: &'a str,
+    ) -> ConnectionValidationFuture<'a>;
 }
 
 impl GreetingServicePort for AppGreetingService {
@@ -31,12 +31,11 @@ impl GreetingServicePort for AppGreetingService {
 }
 
 impl ConnectionServicePort for AppConnectionService {
-    fn validate_sql_server_connection(
-        &self,
-        connection_string: &str,
-    ) -> ConnectionValidationFuture<'_> {
-        let connection_string = connection_string.to_string();
-        Box::pin(async move { self.test_configured_connection(&connection_string).await })
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        connection_string: &'a str,
+    ) -> ConnectionValidationFuture<'a> {
+        Box::pin(self.test_configured_connection(connection_string))
     }
 }
 

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use sql_intelliscan_services::{
     errors::{ServiceError, ServiceResult},
@@ -10,16 +10,45 @@ use sql_intelliscan_services::{
 pub(crate) type AppGreetingService = GreetingService<BackendMetadataRepositoryAdapter>;
 pub(crate) type AppConnectionService = ConnectionService<SqlServerConnectionRepositoryFactory>;
 
+type ConnectionValidationFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<ConnectionTestResult, ServiceError>> + Send + 'a>>;
+
+pub trait GreetingServicePort: Send + Sync {
+    fn greet(&self, name: &str) -> String;
+}
+
+pub trait ConnectionServicePort: Send + Sync {
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        connection_string: &'a str,
+    ) -> ConnectionValidationFuture<'a>;
+}
+
+impl GreetingServicePort for AppGreetingService {
+    fn greet(&self, name: &str) -> String {
+        GreetingService::greet(self, name)
+    }
+}
+
+impl ConnectionServicePort for AppConnectionService {
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        connection_string: &'a str,
+    ) -> ConnectionValidationFuture<'a> {
+        Box::pin(async move { self.test_configured_connection(connection_string).await })
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
-    greeting_service: Arc<AppGreetingService>,
-    connection_service: Arc<AppConnectionService>,
+    greeting_service: Arc<dyn GreetingServicePort>,
+    connection_service: Arc<dyn ConnectionServicePort>,
 }
 
 impl AppState {
-    pub(crate) fn new(
-        greeting_service: Arc<AppGreetingService>,
-        connection_service: Arc<AppConnectionService>,
+    pub fn new(
+        greeting_service: Arc<dyn GreetingServicePort>,
+        connection_service: Arc<dyn ConnectionServicePort>,
     ) -> Self {
         Self {
             greeting_service,
@@ -36,7 +65,7 @@ impl AppState {
         connection_string: &str,
     ) -> Result<ConnectionTestResult, ServiceError> {
         self.connection_service
-            .test_configured_connection(connection_string)
+            .validate_sql_server_connection(connection_string)
             .await
     }
 }

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -1,5 +1,5 @@
 mod app_state;
 mod runtime_state;
 
-pub use app_state::{AppState, AppStateResult};
+pub use app_state::{AppState, AppStateResult, ConnectionServicePort, GreetingServicePort};
 pub(crate) use runtime_state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};

--- a/src/services/tauri_client.rs
+++ b/src/services/tauri_client.rs
@@ -26,9 +26,20 @@ pub struct BackendConnectionTestResult {
     pub is_valid: bool,
 }
 
-#[derive(Serialize)]
-struct ValidateConnectionArgs<'a> {
-    connection_string: &'a str,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ValidateConnectionRequestArgs<'a> {
+    pub connection_string: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ValidateConnectionArgs<'a> {
+    pub request: ValidateConnectionRequestArgs<'a>,
+}
+
+pub fn validate_connection_args(connection_string: &str) -> ValidateConnectionArgs<'_> {
+    ValidateConnectionArgs {
+        request: ValidateConnectionRequestArgs { connection_string },
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -90,7 +101,7 @@ pub async fn invoke_validate_sql_server_connection(
 ) -> Result<CommandSuccessResponse<BackendConnectionTestResult>, CommandErrorResponse> {
     invoke_command(
         "validate_sql_server_connection_command",
-        &ValidateConnectionArgs { connection_string },
+        &validate_connection_args(connection_string),
     )
     .await
 }
@@ -108,7 +119,7 @@ pub async fn invoke_backend_greet(
 pub async fn invoke_validate_sql_server_connection(
     connection_string: &str,
 ) -> Result<CommandSuccessResponse<BackendConnectionTestResult>, CommandErrorResponse> {
-    let _args = ValidateConnectionArgs { connection_string };
+    let _args = validate_connection_args(connection_string);
 
     Ok(CommandSuccessResponse {
         message: "Connection validated successfully".to_string(),

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -92,10 +92,10 @@ impl GreetingServicePort for MockGreetingService {
 struct MockConnectionService;
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 impl ConnectionServicePort for MockConnectionService {
-    fn validate_sql_server_connection(
-        &self,
-        _connection_string: &str,
-    ) -> BoxFuture<'_, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        _connection_string: &'a str,
+    ) -> BoxFuture<'a, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
         Box::pin(async { Err(ServiceError::SourceUnavailable) })
     }
 }

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -1,9 +1,12 @@
 #![allow(non_snake_case)]
 
+use std::{future::Future, pin::Pin, sync::Arc};
+
 use sql_intelliscan_lib::{
     build_app_state, greet_command, greet_with_state, register_handlers,
-    validate_sql_server_connection_command, validate_sql_server_connection_with_state,
-    CommandErrorResponse,
+    validate_sql_server_connection_command, validate_sql_server_connection_with_state, AppState,
+    CommandErrorResponse, ConnectionServicePort, GreetingServicePort, ServiceError,
+    ValidateConnectionRequest,
 };
 use tauri::Manager;
 
@@ -67,7 +70,9 @@ fn GivenManagedStateAndInvalidConnectionString_WhenValidateCommandIsCalled_ThenR
 
     let result = tauri::async_runtime::block_on(validate_sql_server_connection_command(
         app.state(),
-        "Server=localhost;Database=master".to_string(),
+        ValidateConnectionRequest {
+            connection_string: "Server=localhost;Database=master".to_string(),
+        },
     ));
 
     let error = result.expect_err("expected invalid configuration error");
@@ -75,4 +80,41 @@ fn GivenManagedStateAndInvalidConnectionString_WhenValidateCommandIsCalled_ThenR
         error.message,
         "The provided configuration is invalid: missing username."
     );
+}
+
+struct MockGreetingService;
+impl GreetingServicePort for MockGreetingService {
+    fn greet(&self, name: &str) -> String {
+        format!("mock-{name}")
+    }
+}
+
+struct MockConnectionService;
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+impl ConnectionServicePort for MockConnectionService {
+    fn validate_sql_server_connection<'a>(
+        &'a self,
+        _connection_string: &'a str,
+    ) -> BoxFuture<'a, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
+        Box::pin(async { Err(ServiceError::SourceUnavailable) })
+    }
+}
+
+#[test]
+fn GivenMockedServices_WhenValidateCommandRuns_ThenCommand_ShouldDelegateAndMapError() {
+    let app_state = AppState::new(Arc::new(MockGreetingService), Arc::new(MockConnectionService));
+    let app = tauri::test::mock_builder()
+        .manage(app_state)
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("mock app should build");
+
+    let result = tauri::async_runtime::block_on(validate_sql_server_connection_command(
+        app.state(),
+        ValidateConnectionRequest {
+            connection_string: "ignored".to_string(),
+        },
+    ));
+
+    let error = result.expect_err("expected service error");
+    assert_eq!(error.message, "The data source is currently unavailable.");
 }

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -92,10 +92,10 @@ impl GreetingServicePort for MockGreetingService {
 struct MockConnectionService;
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 impl ConnectionServicePort for MockConnectionService {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        _connection_string: &'a str,
-    ) -> BoxFuture<'a, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
+    fn validate_sql_server_connection(
+        &self,
+        _connection_string: &str,
+    ) -> BoxFuture<'_, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
         Box::pin(async { Err(ServiceError::SourceUnavailable) })
     }
 }

--- a/tests/frontend/tauri_client.rs
+++ b/tests/frontend/tauri_client.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use sql_intelliscan_ui::services::tauri_client::{
-    invoke_backend_greet, invoke_validate_sql_server_connection,
+    invoke_backend_greet, invoke_validate_sql_server_connection, validate_connection_args,
 };
 
 #[test]
@@ -22,4 +22,14 @@ fn GivenConnectionString_WhenValidateCommandIsInvoked_ThenMockedResponse_ShouldM
 
     assert_eq!(response.message, "Connection validated successfully");
     assert!(response.data.is_valid);
+}
+
+#[test]
+fn GivenConnectionString_WhenValidateArgsAreBuilt_ThenCommand_ShouldNestRequestPayload() {
+    let args = validate_connection_args("Server=localhost;Database=master");
+
+    assert_eq!(
+        args.request.connection_string,
+        "Server=localhost;Database=master"
+    );
 }


### PR DESCRIPTION
# 🧩 US-003.5 – Implement Service-Level Connection Validation

## 📝 What

🧩 **Implement a service-level SQL Server connection validation in the `services` crate.**  
This feature introduces a `ConnectionService` that validates SQL Server connectivity through the `ConnectionRepositoryContract`, ensuring that Tauri commands interact with the database only via the service layer, not directly with repository implementations.

---

## 💡 Why

🔒 **To enforce architectural boundaries and security:**  
- Ensures the service layer is the only entry point for connection validation.
- Prevents Tauri commands from accessing repository or driver details directly.
- Protects sensitive data (e.g., passwords, connection strings) from being exposed.
- Enables easy mocking and testing of connection logic without a real database.

---

## 🛠️ How

1. **Create/Update `ConnectionService` in `crates/services/src/connection/connection_service.rs`:**
   - Receives an `Arc<dyn ConnectionRepositoryContract + Send + Sync>` in its constructor.
   - Stores the repository dependency privately.

2. **Implement `test_connection` method:**
   - Async method that delegates to the repository contract.
   - Returns a `ConnectionTestResult` on success or a mapped `ServiceError` on failure.

3. **Normalize responses:**
   - Success: Returns only safe, user-friendly fields (no credentials or raw errors).
   - Failure: Maps repository errors to service-level errors, never exposing sensitive info.

4. **Update module exports:**
   - Export `ConnectionService` from the connection module and `lib.rs` for Tauri integration.

5. **Add unit tests:**
   - Use a mock repository to test both success and failure scenarios.
   - Ensure tests do not require a real SQL Server or Tauri runtime.

6. **Security checks:**
   - No `mssqlrust` or SQL queries in the service.
   - No concrete repository types referenced in the service.

```mermaid
flowchart TD
    TauriCommand["Tauri Command"]
    AppState["AppState"]
    ConnectionService["ConnectionService"]
    ConnectionRepositoryContract["ConnectionRepositoryContract"]
    SqlServerConnectionRepository["SqlServerConnectionRepository"]
    mssqlrust["mssqlrust"]

    TauriCommand --> AppState
    AppState --> ConnectionService
    ConnectionService --> ConnectionRepositoryContract
    ConnectionRepositoryContract --> SqlServerConnectionRepository
    SqlServerConnectionRepository --> mssqlrust

    classDef safe fill:#e0ffe0,stroke:#333,stroke-width:2px;
    ConnectionService:::safe
    ConnectionRepositoryContract:::safe
```

---

## 🧪 How to Test

- Run unit tests in `crates/services/src/connection/tests.rs` to verify:
  - Success scenario: Service returns a valid `ConnectionTestResult`.
  - Failure scenario: Service returns a safe `ServiceError`.
- Run workspace build and formatting checks:
  - `cargo check -p services`
  - `cargo check --workspace`
  - `cargo fmt --check`
  - `cargo clippy --workspace --all-targets`
- Search for forbidden dependencies:
  - `rg "mssqlrust" crates/services`
  - `rg "SqlServerConnectionRepository" crates/services`
  - `rg "SELECT " crates/services`

---

## 🗂️ Files changed summary

- **crates/services/src/connection/connection_service.rs**  
  - Created/updated `ConnectionService` struct and async `test_connection` method.
  - Ensured repository is injected as `Arc<dyn ConnectionRepositoryContract + Send + Sync>`.
  - Mapped repository errors to service-level errors.

- **crates/services/src/connection/mod.rs**  
  - Exported `ConnectionService`.

- **crates/services/src/lib.rs**  
  - Exported `connection`, `contracts`, `errors`, and `models` modules.

- **crates/services/src/connection/tests.rs**  
  - Added unit tests for success and failure scenarios using a mock repository.

- **No references to `mssqlrust`, SQL queries, or concrete repository types in the service layer.**

---

## ☑️ Checklist

- [x] `ConnectionService` exists in the `services` crate
- [x] Receives `ConnectionRepositoryContract` via constructor as `Arc<dyn ... + Send + Sync>`
- [x] Exposes async `test_connection` method
- [x] Delegates to repository contract, does not instantiate repositories directly
- [x] No `mssqlrust` or SQL queries in the service
- [x] Maps repository errors to safe service errors
- [x] Success/failure responses are application-safe (no credentials or raw errors)
- [x] Service is exported for Tauri integration
- [x] Unit tests cover both success and failure scenarios with mocks
- [x] Tests do not require SQL Server or Tauri runtime
- [x] `cargo check`, `cargo fmt --check`, and `cargo clippy` all pass
- [x] No forbidden dependencies or leaks in the service layer

---

close #46 