### PR TITLE
🧩 Expose SQL Server Connection Validation Through Tauri Command

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -4,6 +4,7 @@
 - Always read this file before modifying code or tests.
 - After any code or test change, re-run all tests and verify coverage.
 - Coverage must never decrease. Prefer increasing it, especially in modified areas.
+- The primary runtime verification is to execute `cargo tauri dev` and confirm the application starts successfully and keeps running without stopping or crashing.
 
 ---
 

--- a/crates/sql-intelliscan-services/src/errors/service_error.rs
+++ b/crates/sql-intelliscan-services/src/errors/service_error.rs
@@ -15,6 +15,7 @@ pub enum ServiceError {
     InvalidAuditRequest(&'static str),
     InvalidConfiguration(&'static str),
     InvalidName,
+    ConnectionTimeout,
     QueryExecutionFailed,
     ResultMappingFailed(&'static str),
     SourceUnavailable,
@@ -27,8 +28,17 @@ impl From<DataAccessError> for ServiceError {
         match error {
             DataAccessError::SourceUnavailable => Self::SourceUnavailable,
             DataAccessError::InvalidConfiguration(reason) => Self::InvalidConfiguration(reason),
+            DataAccessError::QueryExecutionFailed(reason) if is_timeout_reason(&reason) => {
+                Self::ConnectionTimeout
+            }
             DataAccessError::QueryExecutionFailed(_) => Self::QueryExecutionFailed,
             DataAccessError::ResultMappingFailed(reason) => Self::ResultMappingFailed(reason),
         }
     }
+}
+
+fn is_timeout_reason(reason: &str) -> bool {
+    let normalized = reason.to_ascii_lowercase();
+
+    normalized.contains("timeout") || normalized.contains("timed out")
 }

--- a/crates/sql-intelliscan-services/tests/services.rs
+++ b/crates/sql-intelliscan-services/tests/services.rs
@@ -113,12 +113,23 @@ fn GivenConnectionRepositoryFailure_WhenValidationIsRequested_ThenService_Should
 #[test]
 fn GivenRepositoryQueryFailure_WhenValidationIsRequested_ThenService_ShouldNormalizeError() {
     let service = ConnectionService::new(MockConnectionRepository::fails_with(
-        DataAccessError::QueryExecutionFailed("timeout".to_owned()),
+        DataAccessError::QueryExecutionFailed("validation query failed".to_owned()),
     ));
 
     let result = futures::executor::block_on(service.test_connection());
 
     assert_eq!(result, Err(ServiceError::QueryExecutionFailed));
+}
+
+#[test]
+fn GivenRepositoryTimeout_WhenValidationIsRequested_ThenService_ShouldNormalizeError() {
+    let service = ConnectionService::new(MockConnectionRepository::fails_with(
+        DataAccessError::QueryExecutionFailed("connection timeout".to_owned()),
+    ));
+
+    let result = futures::executor::block_on(service.test_connection());
+
+    assert_eq!(result, Err(ServiceError::ConnectionTimeout));
 }
 
 #[test]

--- a/src-tauri/src/bootstrap/wiring.rs
+++ b/src-tauri/src/bootstrap/wiring.rs
@@ -5,15 +5,18 @@ use sql_intelliscan_services::{
     ConnectionService, GreetingService,
 };
 
-use crate::state::{AppState, AppStateResult};
+use crate::{
+    config::connection_config_loader::CONNECTION_STRING_ENV_VAR,
+    state::{AppState, AppStateResult, ConfiguredConnectionService},
+};
 
 pub fn build_app_state() -> AppStateResult {
     let backend_metadata_repository = BackendMetadataRepositoryAdapter::default_static();
     let greeting_service = Arc::new(GreetingService::new(backend_metadata_repository));
 
-    let command_connection_repository_factory = SqlServerConnectionRepositoryFactory;
-    let command_connection_service = Arc::new(ConnectionService::new(
-        command_connection_repository_factory,
+    let command_connection_service = Arc::new(ConfiguredConnectionService::new(
+        ConnectionService::new(SqlServerConnectionRepositoryFactory),
+        std::env::var(CONNECTION_STRING_ENV_VAR).ok(),
     ));
 
     Ok(AppState::new(greeting_service, command_connection_service))

--- a/src-tauri/src/bootstrap/wiring.rs
+++ b/src-tauri/src/bootstrap/wiring.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
 use sql_intelliscan_services::{
+    errors::ServiceResult,
     repository_wiring::{BackendMetadataRepositoryAdapter, SqlServerConnectionRepositoryFactory},
     ConnectionService, GreetingService,
 };
 
 use crate::{
-    config::connection_config_loader::CONNECTION_STRING_ENV_VAR,
+    config::connection_config_loader::{
+        load_connection_config_from_env_value, CONNECTION_STRING_ENV_VAR,
+    },
     state::{AppState, AppStateResult, ConfiguredConnectionService},
 };
 
@@ -16,8 +19,26 @@ pub fn build_app_state() -> AppStateResult {
 
     let command_connection_service = Arc::new(ConfiguredConnectionService::new(
         ConnectionService::new(SqlServerConnectionRepositoryFactory),
-        std::env::var(CONNECTION_STRING_ENV_VAR).ok(),
+        configured_connection_string_from_env_value(std::env::var(CONNECTION_STRING_ENV_VAR))?,
     ));
 
     Ok(AppState::new(greeting_service, command_connection_service))
+}
+
+pub fn configured_connection_string_from_env_value(
+    configured_connection_string: Result<String, std::env::VarError>,
+) -> ServiceResult<Option<String>> {
+    match configured_connection_string {
+        Ok(connection_string) => {
+            load_connection_config_from_env_value(Ok(connection_string.clone()))?;
+
+            Ok(Some(connection_string))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error @ std::env::VarError::NotUnicode(_)) => {
+            load_connection_config_from_env_value(Err(error))?;
+
+            unreachable!("non-unicode environment values always return an error")
+        }
+    }
 }

--- a/src-tauri/src/commands/connection_commands.rs
+++ b/src-tauri/src/commands/connection_commands.rs
@@ -1,31 +1,17 @@
-use serde::Deserialize;
-use sql_intelliscan_services::models::ConnectionTestResult;
+use crate::{AppState, CommandErrorResponse, ConnectionTestResponse};
 
-use crate::{AppState, CommandErrorResponse, CommandSuccessResponse};
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub struct ValidateConnectionRequest {
-    pub connection_string: String,
-}
-
-pub async fn validate_sql_server_connection_command(
+pub async fn test_connection(
     state: tauri::State<'_, AppState>,
-    request: ValidateConnectionRequest,
-) -> Result<CommandSuccessResponse<ConnectionTestResult>, CommandErrorResponse> {
-    validate_sql_server_connection_with_state(state.inner(), &request.connection_string)
-        .await
-        .map(|result| CommandSuccessResponse {
-            message: "Connection validated successfully".to_string(),
-            data: result,
-        })
-        .map_err(CommandErrorResponse::from_service_error)
+) -> Result<ConnectionTestResponse, CommandErrorResponse> {
+    test_connection_with_state(state.inner()).await
 }
 
-pub async fn validate_sql_server_connection_with_state(
+pub async fn test_connection_with_state(
     state: &AppState,
-    connection_string: &str,
-) -> sql_intelliscan_services::errors::ServiceResult<ConnectionTestResult> {
+) -> Result<ConnectionTestResponse, CommandErrorResponse> {
     state
-        .validate_sql_server_connection(connection_string)
+        .test_connection()
         .await
+        .map(ConnectionTestResponse::from)
+        .map_err(CommandErrorResponse::from_service_error)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,9 +4,7 @@ mod response_models;
 
 use tauri::State;
 
-pub use connection_commands::ValidateConnectionRequest;
-pub use response_models::{CommandErrorResponse, CommandSuccessResponse};
-use sql_intelliscan_services::models::ConnectionTestResult;
+pub use response_models::{CommandErrorResponse, CommandSuccessResponse, ConnectionTestResponse};
 
 use crate::state::AppState;
 
@@ -16,27 +14,22 @@ pub fn greet_command(state: State<'_, AppState>, name: &str) -> CommandSuccessRe
 }
 
 #[tauri::command]
-pub async fn validate_sql_server_connection_command(
+pub async fn test_connection(
     state: State<'_, AppState>,
-    request: ValidateConnectionRequest,
-) -> Result<CommandSuccessResponse<ConnectionTestResult>, CommandErrorResponse> {
-    connection_commands::validate_sql_server_connection_command(state, request).await
+) -> Result<ConnectionTestResponse, CommandErrorResponse> {
+    connection_commands::test_connection(state).await
 }
 
 pub fn greet_with_state(state: &AppState, name: &str) -> String {
     greeting_commands::greet_with_state(state, name)
 }
 
-pub async fn validate_sql_server_connection_with_state(
+pub async fn test_connection_with_state(
     state: &AppState,
-    connection_string: &str,
-) -> sql_intelliscan_services::errors::ServiceResult<ConnectionTestResult> {
-    connection_commands::validate_sql_server_connection_with_state(state, connection_string).await
+) -> Result<ConnectionTestResponse, CommandErrorResponse> {
+    connection_commands::test_connection_with_state(state).await
 }
 
 pub fn register_handlers(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<tauri::Wry> {
-    builder.invoke_handler(tauri::generate_handler![
-        greet_command,
-        validate_sql_server_connection_command
-    ])
+    builder.invoke_handler(tauri::generate_handler![greet_command, test_connection])
 }

--- a/src-tauri/src/commands/response_models.rs
+++ b/src-tauri/src/commands/response_models.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 
 use sql_intelliscan_services::errors::ServiceError;
+use sql_intelliscan_services::models::ConnectionTestResult;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandSuccessResponse<T>
@@ -13,30 +14,56 @@ where
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandErrorResponse {
+    pub code: String,
     pub message: String,
 }
 
 impl CommandErrorResponse {
     pub fn from_service_error(error: ServiceError) -> Self {
-        let message = match error {
-            ServiceError::InvalidAuditRequest(reason) => {
-                format!("The submitted audit request is invalid: {reason}.")
-            }
-            ServiceError::InvalidConfiguration(reason) => {
-                format!("The provided configuration is invalid: {reason}.")
-            }
-            ServiceError::InvalidName => "The provided name is invalid.".to_string(),
-            ServiceError::QueryExecutionFailed => {
-                "The operation failed while querying the data source.".to_string()
-            }
-            ServiceError::ResultMappingFailed(reason) => {
-                format!("The operation could not map the returned data: {reason}.")
-            }
-            ServiceError::SourceUnavailable => {
-                "The data source is currently unavailable.".to_string()
-            }
+        let (code, message) = match error {
+            ServiceError::InvalidAuditRequest(_) | ServiceError::InvalidConfiguration(_) => (
+                "INVALID_CONFIGURATION",
+                "The SQL Server connection configuration is invalid.",
+            ),
+            ServiceError::InvalidName => ("INVALID_CONFIGURATION", "The provided name is invalid."),
+            ServiceError::QueryExecutionFailed => (
+                "CONNECTION_FAILED",
+                "Unable to connect to the SQL Server instance.",
+            ),
+            ServiceError::ResultMappingFailed(_) => (
+                "UNEXPECTED_ERROR",
+                "An unexpected error occurred while testing the connection.",
+            ),
+            ServiceError::SourceUnavailable => (
+                "CONNECTION_FAILED",
+                "Unable to connect to the SQL Server instance.",
+            ),
         };
 
-        Self { message }
+        Self {
+            code: code.to_string(),
+            message: message.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConnectionTestResponse {
+    pub success: bool,
+    pub message: String,
+    pub server_version: Option<String>,
+    pub database: Option<String>,
+    pub latency_ms: Option<u64>,
+}
+
+impl From<ConnectionTestResult> for ConnectionTestResponse {
+    fn from(result: ConnectionTestResult) -> Self {
+        Self {
+            success: result.is_valid,
+            message: result.message,
+            server_version: None,
+            database: result.database,
+            latency_ms: result.latency_ms,
+        }
     }
 }

--- a/src-tauri/src/commands/response_models.rs
+++ b/src-tauri/src/commands/response_models.rs
@@ -21,11 +21,18 @@ pub struct CommandErrorResponse {
 impl CommandErrorResponse {
     pub fn from_service_error(error: ServiceError) -> Self {
         let (code, message) = match error {
+            ServiceError::InvalidConfiguration("authentication failed") => (
+                "AUTHENTICATION_FAILED",
+                "Authentication failed for the SQL Server connection.",
+            ),
             ServiceError::InvalidAuditRequest(_) | ServiceError::InvalidConfiguration(_) => (
                 "INVALID_CONFIGURATION",
                 "The SQL Server connection configuration is invalid.",
             ),
             ServiceError::InvalidName => ("INVALID_CONFIGURATION", "The provided name is invalid."),
+            ServiceError::ConnectionTimeout => {
+                ("TIMEOUT", "The SQL Server connection attempt timed out.")
+            }
             ServiceError::QueryExecutionFailed => (
                 "CONNECTION_FAILED",
                 "Unable to connect to the SQL Server instance.",

--- a/src-tauri/src/config/connection_config_loader.rs
+++ b/src-tauri/src/config/connection_config_loader.rs
@@ -7,9 +7,6 @@ pub const CONNECTION_STRING_ENV_VAR: &str = "SQL_INTELLISCAN_SQLSERVER_CONNECTIO
 
 /// Loads SQL Server configuration from
 /// `SQL_INTELLISCAN_SQLSERVER_CONNECTION_STRING`.
-///
-/// The Tauri application does not call this during startup. Database access is
-/// validated only after the UI submits a user-provided connection string.
 pub fn load_connection_config() -> ServiceResult<SqlServerConnectionConfig> {
     load_connection_config_from_env_value(std::env::var(CONNECTION_STRING_ENV_VAR))
 }

--- a/src-tauri/src/dependency_wiring/service_registry.rs
+++ b/src-tauri/src/dependency_wiring/service_registry.rs
@@ -20,9 +20,6 @@ pub fn greet_user(name: &str) -> Result<String, ServiceError> {
 }
 
 pub async fn validate_sql_server_connection(
-    connection_string: &str,
 ) -> Result<sql_intelliscan_services::models::ConnectionTestResult, ServiceError> {
-    shared_app_state()?
-        .validate_sql_server_connection(connection_string)
-        .await
+    shared_app_state()?.test_connection().await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,9 +6,9 @@ mod dependency_wiring;
 mod state;
 
 pub use commands::{
-    greet_command, greet_with_state, register_handlers, validate_sql_server_connection_command,
-    validate_sql_server_connection_with_state, CommandErrorResponse, CommandSuccessResponse,
-    ValidateConnectionRequest,
+    greet_command, greet_with_state, register_handlers, test_connection,
+    test_connection_with_state, CommandErrorResponse, CommandSuccessResponse,
+    ConnectionTestResponse,
 };
 pub use config::connection_config_loader::{
     load_connection_config, load_connection_config_from_connection_string,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod configuration;
 mod dependency_wiring;
 mod state;
 
+pub use bootstrap::wiring::configured_connection_string_from_env_value;
 pub use commands::{
     greet_command, greet_with_state, register_handlers, test_connection,
     test_connection_with_state, CommandErrorResponse, CommandSuccessResponse,

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -18,10 +18,7 @@ pub trait GreetingServicePort: Send + Sync {
 }
 
 pub trait ConnectionServicePort: Send + Sync {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        connection_string: &'a str,
-    ) -> ConnectionValidationFuture<'a>;
+    fn test_connection(&self) -> ConnectionValidationFuture<'_>;
 }
 
 impl GreetingServicePort for AppGreetingService {
@@ -30,12 +27,33 @@ impl GreetingServicePort for AppGreetingService {
     }
 }
 
-impl ConnectionServicePort for AppConnectionService {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        connection_string: &'a str,
-    ) -> ConnectionValidationFuture<'a> {
-        Box::pin(self.test_configured_connection(connection_string))
+pub struct ConfiguredConnectionService {
+    service: AppConnectionService,
+    connection_string: Option<String>,
+}
+
+impl ConfiguredConnectionService {
+    pub fn new(service: AppConnectionService, connection_string: Option<String>) -> Self {
+        Self {
+            service,
+            connection_string,
+        }
+    }
+}
+
+impl ConnectionServicePort for ConfiguredConnectionService {
+    fn test_connection(&self) -> ConnectionValidationFuture<'_> {
+        Box::pin(async move {
+            let connection_string = self.connection_string.as_deref().ok_or(
+                sql_intelliscan_services::errors::ServiceError::InvalidConfiguration(
+                    "SQL Server connection string is not configured",
+                ),
+            )?;
+
+            self.service
+                .test_configured_connection(connection_string)
+                .await
+        })
     }
 }
 
@@ -60,13 +78,8 @@ impl AppState {
         self.greeting_service.greet(name)
     }
 
-    pub async fn validate_sql_server_connection(
-        &self,
-        connection_string: &str,
-    ) -> ServiceResult<ConnectionTestResult> {
-        self.connection_service
-            .validate_sql_server_connection(connection_string)
-            .await
+    pub async fn test_connection(&self) -> ServiceResult<ConnectionTestResult> {
+        self.connection_service.test_connection().await
     }
 }
 

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -1,5 +1,8 @@
 mod app_state;
 mod runtime_state;
 
-pub use app_state::{AppState, AppStateResult, ConnectionServicePort, GreetingServicePort};
+pub use app_state::{
+    AppState, AppStateResult, ConfiguredConnectionService, ConnectionServicePort,
+    GreetingServicePort,
+};
 pub(crate) use runtime_state::{backend_runner, run_hooks, BackendRunner, BuilderFactory, Runner};

--- a/src/services/connection_service.rs
+++ b/src/services/connection_service.rs
@@ -6,6 +6,7 @@ use crate::services::tauri_client::{
 pub struct ConnectionTestStatus {
     pub success: bool,
     pub message: String,
+    pub server_version: Option<String>,
     pub database: Option<String>,
     pub latency_ms: Option<u64>,
 }
@@ -27,6 +28,7 @@ pub fn map_connection_test_result(response: BackendConnectionTestResult) -> Conn
     ConnectionTestStatus {
         success: response.success,
         message: response.message,
+        server_version: response.server_version,
         database: response.database,
         latency_ms: response.latency_ms,
     }

--- a/src/services/connection_service.rs
+++ b/src/services/connection_service.rs
@@ -1,12 +1,13 @@
 use crate::services::tauri_client::{
-    invoke_validate_sql_server_connection, BackendConnectionTestResult, CommandErrorResponse,
-    CommandSuccessResponse,
+    invoke_test_connection, BackendConnectionTestResult, CommandErrorResponse,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectionTestStatus {
-    pub is_valid: bool,
+    pub success: bool,
     pub message: String,
+    pub database: Option<String>,
+    pub latency_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,23 +15,20 @@ pub struct FrontendServiceError {
     pub message: String,
 }
 
-pub async fn test_connection(
-    connection_string: &str,
-) -> Result<ConnectionTestStatus, FrontendServiceError> {
-    let connection_string = normalize_connection_string(connection_string)?;
-    let response = invoke_validate_sql_server_connection(connection_string)
+pub async fn test_connection() -> Result<ConnectionTestStatus, FrontendServiceError> {
+    let response = invoke_test_connection()
         .await
         .map_err(normalize_backend_error)?;
 
     Ok(map_connection_test_result(response))
 }
 
-pub fn map_connection_test_result(
-    response: CommandSuccessResponse<BackendConnectionTestResult>,
-) -> ConnectionTestStatus {
+pub fn map_connection_test_result(response: BackendConnectionTestResult) -> ConnectionTestStatus {
     ConnectionTestStatus {
-        is_valid: response.data.is_valid,
+        success: response.success,
         message: response.message,
+        database: response.database,
+        latency_ms: response.latency_ms,
     }
 }
 
@@ -38,18 +36,6 @@ pub fn normalize_backend_error(error: CommandErrorResponse) -> FrontendServiceEr
     FrontendServiceError {
         message: normalize_error_message(&error.message),
     }
-}
-
-fn normalize_connection_string(connection_string: &str) -> Result<&str, FrontendServiceError> {
-    let trimmed = connection_string.trim();
-
-    if trimmed.is_empty() {
-        return Err(FrontendServiceError {
-            message: "Connection string is required.".to_string(),
-        });
-    }
-
-    Ok(trimmed)
 }
 
 fn normalize_error_message(message: &str) -> String {

--- a/src/services/tauri_client.rs
+++ b/src/services/tauri_client.rs
@@ -117,7 +117,7 @@ pub async fn invoke_backend_greet(
 pub async fn invoke_test_connection() -> Result<BackendConnectionTestResult, CommandErrorResponse> {
     Ok(BackendConnectionTestResult {
         success: true,
-        message: "Connection validated successfully".to_string(),
+        message: "Connection successful".to_string(),
         server_version: None,
         database: Some("master".to_string()),
         latency_ms: Some(1),

--- a/src/services/tauri_client.rs
+++ b/src/services/tauri_client.rs
@@ -18,28 +18,17 @@ pub struct CommandSuccessResponse<T> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CommandErrorResponse {
+    pub code: String,
     pub message: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct BackendConnectionTestResult {
-    pub is_valid: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ValidateConnectionRequestArgs<'a> {
-    pub connection_string: &'a str,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ValidateConnectionArgs<'a> {
-    pub request: ValidateConnectionRequestArgs<'a>,
-}
-
-pub fn validate_connection_args(connection_string: &str) -> ValidateConnectionArgs<'_> {
-    ValidateConnectionArgs {
-        request: ValidateConnectionRequestArgs { connection_string },
-    }
+    pub success: bool,
+    pub message: String,
+    pub server_version: Option<String>,
+    pub database: Option<String>,
+    pub latency_ms: Option<u64>,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -69,17 +58,20 @@ where
 {
     if !has_tauri_invoke() {
         return Err(CommandErrorResponse {
+            code: "BACKEND_UNAVAILABLE".to_string(),
             message: "Tauri backend is not available.".to_string(),
         });
     }
 
     let args = serde_wasm_bindgen::to_value(args).map_err(|_| CommandErrorResponse {
+        code: "INVALID_ARGUMENTS".to_string(),
         message: "The frontend could not prepare backend command arguments.".to_string(),
     })?;
 
     let response = invoke(command, args).await;
 
     serde_wasm_bindgen::from_value(response).map_err(|_| CommandErrorResponse {
+        code: "UNEXPECTED_RESPONSE".to_string(),
         message: "The backend returned an unexpected response.".to_string(),
     })
 }
@@ -96,14 +88,20 @@ pub async fn invoke_backend_greet(
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn invoke_validate_sql_server_connection(
-    connection_string: &str,
-) -> Result<CommandSuccessResponse<BackendConnectionTestResult>, CommandErrorResponse> {
-    invoke_command(
-        "validate_sql_server_connection_command",
-        &validate_connection_args(connection_string),
-    )
-    .await
+pub async fn invoke_test_connection() -> Result<BackendConnectionTestResult, CommandErrorResponse> {
+    if !has_tauri_invoke() {
+        return Err(CommandErrorResponse {
+            code: "BACKEND_UNAVAILABLE".to_string(),
+            message: "Tauri backend is not available.".to_string(),
+        });
+    }
+
+    let response = invoke("test_connection", js_sys::Object::new().into()).await;
+
+    serde_wasm_bindgen::from_value(response).map_err(|_| CommandErrorResponse {
+        code: "UNEXPECTED_RESPONSE".to_string(),
+        message: "The backend returned an unexpected response.".to_string(),
+    })
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -116,14 +114,13 @@ pub async fn invoke_backend_greet(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn invoke_validate_sql_server_connection(
-    connection_string: &str,
-) -> Result<CommandSuccessResponse<BackendConnectionTestResult>, CommandErrorResponse> {
-    let _args = validate_connection_args(connection_string);
-
-    Ok(CommandSuccessResponse {
+pub async fn invoke_test_connection() -> Result<BackendConnectionTestResult, CommandErrorResponse> {
+    Ok(BackendConnectionTestResult {
+        success: true,
         message: "Connection validated successfully".to_string(),
-        data: BackendConnectionTestResult { is_valid: true },
+        server_version: None,
+        database: Some("master".to_string()),
+        latency_ms: Some(1),
     })
 }
 

--- a/tests/backend/app_state.rs
+++ b/tests/backend/app_state.rs
@@ -17,9 +17,8 @@ impl GreetingServicePort for MockGreetingService {
 struct MockConnectionService;
 
 impl ConnectionServicePort for MockConnectionService {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        _connection_string: &'a str,
+    fn test_connection(
+        &self,
     ) -> Pin<
         Box<
             dyn Future<
@@ -28,7 +27,7 @@ impl ConnectionServicePort for MockConnectionService {
                         ServiceError,
                     >,
                 > + Send
-                + 'a,
+                + '_,
         >,
     > {
         Box::pin(async { Ok(sql_intelliscan_lib::models::ConnectionTestResult::valid()) })
@@ -49,25 +48,21 @@ fn GivenDependencyWiring_WhenAppStateIsBuilt_ThenServices_ShouldBeResolved() {
 fn GivenInvalidConnectionString_WhenAppStateValidatesConnection_ThenError_ShouldBeClear() {
     let app_state = build_app_state().expect("app state should build");
 
-    let result = tauri::async_runtime::block_on(
-        app_state.validate_sql_server_connection("Server=localhost;Database=master"),
-    );
+    let result = tauri::async_runtime::block_on(app_state.test_connection());
 
     let error = result.expect_err("expected invalid configuration error");
-    assert_eq!(error, ServiceError::InvalidConfiguration("missing username"));
+    assert_eq!(
+        error,
+        ServiceError::InvalidConfiguration("SQL Server connection string is not configured")
+    );
 }
 
 #[test]
-fn GivenConfiguredConnectionString_WhenStateValidatesConnection_ThenResult_ShouldIncludeSafeDetails()
-{
+fn GivenConfiguredConnectionService_WhenStateTestsConnection_ThenResult_ShouldIncludeSafeDetails() {
     let app_state = AppState::new(Arc::new(MockGreetingService), Arc::new(MockConnectionService));
 
-    let result = tauri::async_runtime::block_on(
-        app_state.validate_sql_server_connection(
-            "Server=localhost;Database=master;User Id=sa;Password=secret",
-        ),
-    )
-    .expect("configured validation should succeed");
+    let result = tauri::async_runtime::block_on(app_state.test_connection())
+        .expect("configured validation should succeed");
 
     assert!(result.is_valid);
 }

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -3,10 +3,9 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use sql_intelliscan_lib::{
-    build_app_state, greet_command, greet_with_state, register_handlers,
-    validate_sql_server_connection_command, validate_sql_server_connection_with_state, AppState,
-    CommandErrorResponse, ConnectionServicePort, GreetingServicePort, ServiceError,
-    ValidateConnectionRequest,
+    build_app_state, greet_command, greet_with_state, register_handlers, test_connection,
+    test_connection_with_state, AppState, CommandErrorResponse, ConnectionServicePort,
+    ConnectionTestResponse, GreetingServicePort, ServiceError,
 };
 use tauri::Manager;
 
@@ -27,21 +26,17 @@ fn GivenBuilder_WhenHandlersAreRegistered_ThenPipeline_ShouldBeComposable() {
 }
 
 #[test]
-fn GivenInvalidConnectionString_WhenValidateCommandHandlerIsCalled_ThenResult_ShouldReturnFriendlyError(
+fn GivenMissingConfiguration_WhenTestConnectionHandlerIsCalled_ThenResult_ShouldReturnFriendlyError(
 ) {
     let app_state = build_app_state().expect("app state should build");
 
-    let result = tauri::async_runtime::block_on(validate_sql_server_connection_with_state(
-        &app_state,
-        "Server=localhost;Database=master",
-    ));
+    let result = tauri::async_runtime::block_on(test_connection_with_state(&app_state));
 
     let error = result.expect_err("expected invalid configuration error");
-    let mapped_error = CommandErrorResponse::from_service_error(error);
-
+    assert_eq!(error.code, "INVALID_CONFIGURATION");
     assert_eq!(
-        mapped_error.message,
-        "The provided configuration is invalid: missing username."
+        error.message,
+        "The SQL Server connection configuration is invalid."
     );
 }
 
@@ -60,7 +55,7 @@ fn GivenManagedState_WhenGreetCommandIsCalled_ThenResponse_ShouldWrapGreetingMes
 }
 
 #[test]
-fn GivenManagedStateAndInvalidConnectionString_WhenValidateCommandIsCalled_ThenResponse_ShouldReturnFriendlyError(
+fn GivenManagedStateAndMissingConfiguration_WhenTestConnectionIsCalled_ThenResponse_ShouldReturnFriendlyError(
 ) {
     let app_state = build_app_state().expect("app state should build");
     let app = tauri::test::mock_builder()
@@ -68,17 +63,13 @@ fn GivenManagedStateAndInvalidConnectionString_WhenValidateCommandIsCalled_ThenR
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .expect("mock app should build");
 
-    let result = tauri::async_runtime::block_on(validate_sql_server_connection_command(
-        app.state(),
-        ValidateConnectionRequest {
-            connection_string: "Server=localhost;Database=master".to_string(),
-        },
-    ));
+    let result = tauri::async_runtime::block_on(test_connection(app.state()));
 
     let error = result.expect_err("expected invalid configuration error");
+    assert_eq!(error.code, "INVALID_CONFIGURATION");
     assert_eq!(
         error.message,
-        "The provided configuration is invalid: missing username."
+        "The SQL Server connection configuration is invalid."
     );
 }
 
@@ -92,29 +83,74 @@ impl GreetingServicePort for MockGreetingService {
 struct MockConnectionService;
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 impl ConnectionServicePort for MockConnectionService {
-    fn validate_sql_server_connection<'a>(
-        &'a self,
-        _connection_string: &'a str,
-    ) -> BoxFuture<'a, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
+    fn test_connection(
+        &self,
+    ) -> BoxFuture<'_, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
         Box::pin(async { Err(ServiceError::SourceUnavailable) })
     }
 }
 
 #[test]
-fn GivenMockedServices_WhenValidateCommandRuns_ThenCommand_ShouldDelegateAndMapError() {
+fn GivenMockedServices_WhenTestConnectionCommandRuns_ThenCommand_ShouldDelegateAndMapError() {
     let app_state = AppState::new(Arc::new(MockGreetingService), Arc::new(MockConnectionService));
     let app = tauri::test::mock_builder()
         .manage(app_state)
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .expect("mock app should build");
 
-    let result = tauri::async_runtime::block_on(validate_sql_server_connection_command(
-        app.state(),
-        ValidateConnectionRequest {
-            connection_string: "ignored".to_string(),
-        },
-    ));
+    let result = tauri::async_runtime::block_on(test_connection(app.state()));
 
     let error = result.expect_err("expected service error");
-    assert_eq!(error.message, "The data source is currently unavailable.");
+    assert_eq!(error.code, "CONNECTION_FAILED");
+    assert_eq!(
+        error.message,
+        "Unable to connect to the SQL Server instance."
+    );
+}
+
+struct SuccessfulConnectionService;
+impl ConnectionServicePort for SuccessfulConnectionService {
+    fn test_connection(
+        &self,
+    ) -> BoxFuture<'_, Result<sql_intelliscan_lib::models::ConnectionTestResult, ServiceError>> {
+        Box::pin(async {
+            Ok(sql_intelliscan_lib::models::ConnectionTestResult::valid_with_details(
+                Some("master".to_string()),
+                Some(42),
+            ))
+        })
+    }
+}
+
+#[test]
+fn GivenSuccessfulServiceResult_WhenTestConnectionCommandRuns_ThenResponse_ShouldContainOnlySafeFields(
+) {
+    let app_state = AppState::new(
+        Arc::new(MockGreetingService),
+        Arc::new(SuccessfulConnectionService),
+    );
+    let app = tauri::test::mock_builder()
+        .manage(app_state)
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("mock app should build");
+
+    let response: ConnectionTestResponse = tauri::async_runtime::block_on(test_connection(app.state()))
+        .expect("connection test should succeed");
+
+    assert!(response.success);
+    assert_eq!(response.message, "Connection successful");
+    assert_eq!(response.database.as_deref(), Some("master"));
+    assert_eq!(response.latency_ms, Some(42));
+    assert_eq!(response.server_version, None);
+}
+
+#[test]
+fn GivenServiceError_WhenMappedToCommandError_ThenResponse_ShouldUseStableSafeCode() {
+    let error = CommandErrorResponse::from_service_error(ServiceError::QueryExecutionFailed);
+
+    assert_eq!(error.code, "CONNECTION_FAILED");
+    assert_eq!(
+        error.message,
+        "Unable to connect to the SQL Server instance."
+    );
 }

--- a/tests/backend/response_models.rs
+++ b/tests/backend/response_models.rs
@@ -15,7 +15,17 @@ fn GivenServiceErrors_WhenMappedToCommandErrorResponse_ThenCodesAndMessages_Shou
             "INVALID_CONFIGURATION",
             "The SQL Server connection configuration is invalid.",
         ),
+        (
+            ServiceError::InvalidConfiguration("authentication failed"),
+            "AUTHENTICATION_FAILED",
+            "Authentication failed for the SQL Server connection.",
+        ),
         (ServiceError::InvalidName, "INVALID_CONFIGURATION", "The provided name is invalid."),
+        (
+            ServiceError::ConnectionTimeout,
+            "TIMEOUT",
+            "The SQL Server connection attempt timed out.",
+        ),
         (
             ServiceError::QueryExecutionFailed,
             "CONNECTION_FAILED",

--- a/tests/backend/response_models.rs
+++ b/tests/backend/response_models.rs
@@ -3,37 +3,40 @@
 use sql_intelliscan_lib::{CommandErrorResponse, CommandSuccessResponse, ServiceError};
 
 #[test]
-fn GivenServiceErrors_WhenMappedToCommandErrorResponse_ThenMessages_ShouldBeUserFriendly() {
+fn GivenServiceErrors_WhenMappedToCommandErrorResponse_ThenCodesAndMessages_ShouldBeFrontendSafe() {
     let cases = [
         (
             ServiceError::InvalidAuditRequest("missing target"),
-            "The submitted audit request is invalid: missing target.",
+            "INVALID_CONFIGURATION",
+            "The SQL Server connection configuration is invalid.",
         ),
         (
             ServiceError::InvalidConfiguration("missing password"),
-            "The provided configuration is invalid: missing password.",
+            "INVALID_CONFIGURATION",
+            "The SQL Server connection configuration is invalid.",
         ),
-        (
-            ServiceError::InvalidName,
-            "The provided name is invalid.",
-        ),
+        (ServiceError::InvalidName, "INVALID_CONFIGURATION", "The provided name is invalid."),
         (
             ServiceError::QueryExecutionFailed,
-            "The operation failed while querying the data source.",
+            "CONNECTION_FAILED",
+            "Unable to connect to the SQL Server instance.",
         ),
         (
             ServiceError::ResultMappingFailed("unexpected scalar"),
-            "The operation could not map the returned data: unexpected scalar.",
+            "UNEXPECTED_ERROR",
+            "An unexpected error occurred while testing the connection.",
         ),
         (
             ServiceError::SourceUnavailable,
-            "The data source is currently unavailable.",
+            "CONNECTION_FAILED",
+            "Unable to connect to the SQL Server instance.",
         ),
     ];
 
-    for (error, expected_message) in cases {
+    for (error, expected_code, expected_message) in cases {
         let response = CommandErrorResponse::from_service_error(error);
 
+        assert_eq!(response.code, expected_code);
         assert_eq!(response.message, expected_message);
     }
 }

--- a/tests/backend/service_registry.rs
+++ b/tests/backend/service_registry.rs
@@ -10,27 +10,12 @@ fn GivenValidName_WhenGreetUserIsCalled_ThenMessage_ShouldIncludeNameAndBackendO
 }
 
 #[test]
-fn GivenInvalidConnectionString_WhenValidationIsRequested_ThenResult_ShouldMapConfigurationError() {
-    let result = tauri::async_runtime::block_on(validate_sql_server_connection(
-        "Server=localhost;Database=master",
-    ));
+fn GivenMissingConfiguration_WhenValidationIsRequested_ThenResult_ShouldMapConfigurationError() {
+    let result = tauri::async_runtime::block_on(validate_sql_server_connection());
 
     let error = result.expect_err("expected invalid configuration error");
-    assert_eq!(error, ServiceError::InvalidConfiguration("missing username"));
-}
-
-#[test]
-fn GivenUnavailableServer_WhenValidationIsRequested_ThenResult_ShouldMapSourceUnavailable() {
-    let result = tauri::async_runtime::block_on(validate_sql_server_connection(
-        "Server=127.0.0.1,1;Database=master;User Id=sa;Password=bad-password;TrustServerCertificate=true;Encrypt=false;Connection Timeout=1",
-    ));
-
-    let error = result.expect_err("expected connection failure error");
-    assert!(
-        matches!(
-            error,
-            ServiceError::SourceUnavailable | ServiceError::QueryExecutionFailed
-        ),
-        "unexpected error variant: {error:?}"
+    assert_eq!(
+        error,
+        ServiceError::InvalidConfiguration("SQL Server connection string is not configured")
     );
 }

--- a/tests/backend/wiring.rs
+++ b/tests/backend/wiring.rs
@@ -13,14 +13,15 @@ fn GivenNoDatabaseCredentials_WhenAppStateIsBuilt_ThenServices_ShouldBeResolved(
 }
 
 #[test]
-fn GivenInvalidUserProvidedConnectionString_WhenConnectionIsValidated_ThenError_ShouldBeSafe() {
+fn GivenNoConfiguredConnectionString_WhenConnectionIsValidated_ThenError_ShouldBeSafe() {
     let app_state = build_app_state().expect("app state should build without database credentials");
 
-    let result = tauri::async_runtime::block_on(
-        app_state.validate_sql_server_connection("Server=localhost;Database=master"),
-    );
+    let result = tauri::async_runtime::block_on(app_state.test_connection());
 
     let error = result.expect_err("invalid configured connection should fail safely");
 
-    assert_eq!(error, ServiceError::InvalidConfiguration("missing username"));
+    assert_eq!(
+        error,
+        ServiceError::InvalidConfiguration("SQL Server connection string is not configured")
+    );
 }

--- a/tests/backend/wiring.rs
+++ b/tests/backend/wiring.rs
@@ -1,6 +1,10 @@
 #![allow(non_snake_case)]
 
-use sql_intelliscan_lib::{build_app_state, ServiceError};
+use std::{env::VarError, ffi::OsString};
+
+use sql_intelliscan_lib::{
+    build_app_state, configured_connection_string_from_env_value, ServiceError,
+};
 
 #[test]
 fn GivenNoDatabaseCredentials_WhenAppStateIsBuilt_ThenServices_ShouldBeResolved() {
@@ -23,5 +27,31 @@ fn GivenNoConfiguredConnectionString_WhenConnectionIsValidated_ThenError_ShouldB
     assert_eq!(
         error,
         ServiceError::InvalidConfiguration("SQL Server connection string is not configured")
+    );
+}
+
+#[test]
+fn GivenEmptyEnvironmentConnectionString_WhenWiringReadsConfig_ThenError_ShouldFailFast() {
+    let result = configured_connection_string_from_env_value(Ok("   ".to_string()));
+
+    let error = result.expect_err("empty configured value should fail before wiring state");
+
+    assert_eq!(
+        error,
+        ServiceError::InvalidConfiguration("SQL Server connection string must not be empty")
+    );
+}
+
+#[test]
+fn GivenNonUnicodeEnvironmentConnectionString_WhenWiringReadsConfig_ThenError_ShouldFailFast() {
+    let result = configured_connection_string_from_env_value(Err(VarError::NotUnicode(
+        OsString::from("malformed"),
+    )));
+
+    let error = result.expect_err("non-unicode configured value should fail before wiring state");
+
+    assert_eq!(
+        error,
+        ServiceError::InvalidConfiguration("SQL Server connection string must be valid Unicode")
     );
 }

--- a/tests/frontend/connection_service.rs
+++ b/tests/frontend/connection_service.rs
@@ -3,24 +3,28 @@
 use sql_intelliscan_ui::services::connection_service::{
     map_connection_test_result, normalize_backend_error, test_connection,
 };
-use sql_intelliscan_ui::services::tauri_client::{
-    BackendConnectionTestResult, CommandErrorResponse, CommandSuccessResponse,
-};
+use sql_intelliscan_ui::services::tauri_client::{BackendConnectionTestResult, CommandErrorResponse};
 
 #[test]
 fn GivenBackendConnectionResult_WhenMapped_ThenFrontendModel_ShouldExposeFriendlyStatus() {
-    let status = map_connection_test_result(CommandSuccessResponse {
+    let status = map_connection_test_result(BackendConnectionTestResult {
+        success: true,
         message: "Connection validated successfully".to_string(),
-        data: BackendConnectionTestResult { is_valid: true },
+        server_version: None,
+        database: Some("master".to_string()),
+        latency_ms: Some(42),
     });
 
-    assert!(status.is_valid);
+    assert!(status.success);
     assert_eq!(status.message, "Connection validated successfully");
+    assert_eq!(status.database.as_deref(), Some("master"));
+    assert_eq!(status.latency_ms, Some(42));
 }
 
 #[test]
 fn GivenBackendErrorWithWhitespace_WhenNormalized_ThenServiceError_ShouldTrimMessage() {
     let error = normalize_backend_error(CommandErrorResponse {
+        code: "CONNECTION_FAILED".to_string(),
         message: "  The provided configuration is invalid.  ".to_string(),
     });
 
@@ -30,6 +34,7 @@ fn GivenBackendErrorWithWhitespace_WhenNormalized_ThenServiceError_ShouldTrimMes
 #[test]
 fn GivenBackendErrorWithoutMessage_WhenNormalized_ThenServiceError_ShouldUseFallbackMessage() {
     let error = normalize_backend_error(CommandErrorResponse {
+        code: "UNEXPECTED_ERROR".to_string(),
         message: " \t\n ".to_string(),
     });
 
@@ -37,18 +42,10 @@ fn GivenBackendErrorWithoutMessage_WhenNormalized_ThenServiceError_ShouldUseFall
 }
 
 #[test]
-fn GivenEmptyConnectionString_WhenConnectionIsTested_ThenService_ShouldReturnValidationError() {
-    let error = futures::executor::block_on(test_connection("  "))
-        .expect_err("empty connection string should be rejected by frontend service");
-
-    assert_eq!(error.message, "Connection string is required.");
-}
-
-#[test]
-fn GivenConnectionStringWithWhitespace_WhenConnectionIsTested_ThenService_ShouldUseTauriClient() {
-    let status = futures::executor::block_on(test_connection("  Server=localhost  "))
+fn GivenNoConnectionPayload_WhenConnectionIsTested_ThenService_ShouldUseTauriClient() {
+    let status = futures::executor::block_on(test_connection())
         .expect("native frontend test uses a mocked Tauri client");
 
-    assert!(status.is_valid);
+    assert!(status.success);
     assert_eq!(status.message, "Connection validated successfully");
 }

--- a/tests/frontend/connection_service.rs
+++ b/tests/frontend/connection_service.rs
@@ -9,14 +9,18 @@ use sql_intelliscan_ui::services::tauri_client::{BackendConnectionTestResult, Co
 fn GivenBackendConnectionResult_WhenMapped_ThenFrontendModel_ShouldExposeFriendlyStatus() {
     let status = map_connection_test_result(BackendConnectionTestResult {
         success: true,
-        message: "Connection validated successfully".to_string(),
-        server_version: None,
+        message: "Connection successful".to_string(),
+        server_version: Some("Microsoft SQL Server 2022".to_string()),
         database: Some("master".to_string()),
         latency_ms: Some(42),
     });
 
     assert!(status.success);
-    assert_eq!(status.message, "Connection validated successfully");
+    assert_eq!(status.message, "Connection successful");
+    assert_eq!(
+        status.server_version.as_deref(),
+        Some("Microsoft SQL Server 2022")
+    );
     assert_eq!(status.database.as_deref(), Some("master"));
     assert_eq!(status.latency_ms, Some(42));
 }
@@ -47,5 +51,5 @@ fn GivenNoConnectionPayload_WhenConnectionIsTested_ThenService_ShouldUseTauriCli
         .expect("native frontend test uses a mocked Tauri client");
 
     assert!(status.success);
-    assert_eq!(status.message, "Connection validated successfully");
+    assert_eq!(status.message, "Connection successful");
 }

--- a/tests/frontend/greeting_service.rs
+++ b/tests/frontend/greeting_service.rs
@@ -16,6 +16,7 @@ fn GivenSuccessfulGreetResponse_WhenMapped_ThenMessage_ShouldUseBackendData() {
 #[test]
 fn GivenFailedGreetResponse_WhenMapped_ThenMessage_ShouldExposeBackendError() {
     let message = map_greet_response(Err(CommandErrorResponse {
+        code: "UNEXPECTED_RESPONSE".to_string(),
         message: "The backend returned an unexpected response.".to_string(),
     }));
 

--- a/tests/frontend/tauri_client.rs
+++ b/tests/frontend/tauri_client.rs
@@ -18,7 +18,7 @@ fn GivenNoPayload_WhenTestConnectionCommandIsInvoked_ThenMockedResponse_ShouldMa
     let response = futures::executor::block_on(invoke_test_connection())
         .expect("native frontend test should use mocked Tauri response");
 
-    assert_eq!(response.message, "Connection validated successfully");
+    assert_eq!(response.message, "Connection successful");
     assert!(response.success);
     assert_eq!(response.database.as_deref(), Some("master"));
 }

--- a/tests/frontend/tauri_client.rs
+++ b/tests/frontend/tauri_client.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use sql_intelliscan_ui::services::tauri_client::{
-    invoke_backend_greet, invoke_validate_sql_server_connection, validate_connection_args,
+    invoke_backend_greet, invoke_test_connection,
 };
 
 #[test]
@@ -14,22 +14,11 @@ fn GivenName_WhenGreetCommandIsInvoked_ThenMockedResponse_ShouldMatchBackendShap
 }
 
 #[test]
-fn GivenConnectionString_WhenValidateCommandIsInvoked_ThenMockedResponse_ShouldMatchBackendShape() {
-    let response = futures::executor::block_on(invoke_validate_sql_server_connection(
-        "Server=localhost;Database=master",
-    ))
-    .expect("native frontend test should use mocked Tauri response");
+fn GivenNoPayload_WhenTestConnectionCommandIsInvoked_ThenMockedResponse_ShouldMatchBackendShape() {
+    let response = futures::executor::block_on(invoke_test_connection())
+        .expect("native frontend test should use mocked Tauri response");
 
     assert_eq!(response.message, "Connection validated successfully");
-    assert!(response.data.is_valid);
-}
-
-#[test]
-fn GivenConnectionString_WhenValidateArgsAreBuilt_ThenCommand_ShouldNestRequestPayload() {
-    let args = validate_connection_args("Server=localhost;Database=master");
-
-    assert_eq!(
-        args.request.connection_string,
-        "Server=localhost;Database=master"
-    );
+    assert!(response.success);
+    assert_eq!(response.database.as_deref(), Some("master"));
 }


### PR DESCRIPTION
# 🧩 Expose SQL Server Connection Validation Through Tauri Command

---

## ❓ What

Permite a la aplicación validar la conexión a SQL Server mediante un comando Tauri, exponiendo la validación al frontend de manera segura y desacoplada de la lógica de negocio o detalles de implementación del repositorio.

---

## 💡 Why

- Los usuarios necesitan confirmar que la aplicación puede conectarse a SQL Server antes de ejecutar análisis o acciones dependientes de la base de datos.
- Mejora la experiencia de usuario al permitir validaciones previas y mensajes claros de error.
- Refuerza la arquitectura desacoplada y segura, evitando la exposición de detalles sensibles o internos.

---

## 🛠️ How

- Se creó/actualizó el módulo de comandos de conexión en `src-tauri/src/commands/connection_commands.rs`.
- Se definió un modelo de respuesta serializable y seguro para el frontend (`ConnectionTestResponse`).
- Se definió un modelo de error seguro para el frontend (`CommandErrorResponse`).
- Se implementó el comando Tauri `test_connection` que:
  - Recibe `State<AppState>`.
  - Llama a `ConnectionService.test_connection`.
  - Mapea el resultado a un modelo seguro para el frontend.
  - Mapea los errores del servicio a errores seguros y categorizados.
- Se registró el comando en el handler de Tauri.
- Se actualizaron los contratos y servicios para reflejar la nueva interfaz y eliminar dependencias de detalles internos.
- Se agregaron pruebas unitarias para el mapeo de errores.
- Se validó que no se expongan datos sensibles ni se utilicen detalles de bajo nivel en el comando.

---

## 🧩 Mermaid Diagram

```mermaid
flowchart TD
    A[Leptos Frontend Service] -->|"invoke('test_connection')"| B[Tauri Command: test_connection]
    B -->|"State<AppState>"| C[ConnectionService]
    C -->|"test_connection()"| D[ConnectionRepositoryContract]
    D -->|SQL Server Validation| E[SqlServerConnectionRepository]
    E -->|mssqlrust| F["(SQL Server)"]
    B -->|"Frontend-safe Response/Error"| A
```

---

## 🧪 How to test

1. Ejecuta `cargo tauri dev` y verifica que la aplicación inicia correctamente.
2. Desde el frontend, invoca el comando `test_connection`.
3. Verifica que:
   - Si la conexión es válida, recibes un objeto `ConnectionTestResponse` con `success: true`.
   - Si hay error de autenticación, recibes un error con código `AUTHENTICATION_FAILED`.
   - Si hay timeout, recibes un error con código `TIMEOUT`.
   - Si hay fallo de conexión, recibes un error con código `CONNECTION_FAILED`.
   - Nunca se expone el password, connection string completo ni mensajes internos del driver.
4. Corre los tests y verifica que la cobertura no disminuye:
   - `cargo check -p services`
   - `cargo check -p repository`
   - `cargo check --workspace`
   - `cargo fmt --check`
   - `cargo clippy --workspace --all-targets`
5. Opcional: Busca en el código para asegurar que no hay referencias a `mssqlrust`, queries SQL o exposición de credenciales en los comandos Tauri.

---

## 🗂️ Files changed summary

- **src-tauri/src/commands/connection_commands.rs**: Implementación del comando `test_connection` y mapeo de errores/resultados.
- **src-tauri/src/commands/mod.rs**: Exportación y registro del nuevo comando.
- **src-tauri/src/commands/response_models.rs**: Nuevos modelos de respuesta y error seguros para el frontend.
- **src-tauri/src/state/app_state.rs**: Adaptación de la interfaz del servicio y wiring para soportar la nueva validación.
- **src-tauri/src/bootstrap/wiring.rs**: Wiring actualizado para el nuevo servicio de conexión.
- **src-tauri/src/lib.rs**: Exportación y registro del comando.
- **src/services/connection_service.rs** y **src/services/tauri_client.rs**: Adaptación del frontend para consumir el nuevo contrato y modelo de respuesta.
- **src-tauri/src/config/connection_config_loader.rs**, **src-tauri/src/dependency_wiring/service_registry.rs**, **src-tauri/src/state/mod.rs**: Refactor y limpieza de dependencias y wiring.

---

## ☑️ Checklist

- [x] Existe un comando Tauri para validar la conexión SQL Server (`test_connection`)
- [x] El comando recibe `State<AppState>`
- [x] El comando llama a `ConnectionService.test_connection`
- [x] El comando retorna un modelo seguro para el frontend
- [x] Los errores del servicio se mapean a errores seguros y categorizados
- [x] No se instancia el repositorio ni el servicio en el comando
- [x] No se importa ni usa `mssqlrust` en el comando
- [x] No hay queries SQL en el comando
- [x] No se expone password, connection string ni credenciales
- [x] El comando está registrado en el handler de Tauri
- [x] El frontend puede invocar el comando exitosamente
- [x] Pruebas unitarias para el mapeo de errores
- [x] `cargo fmt --check` pasa
- [x] `cargo clippy --workspace --all-targets` pasa
- [x] El workspace compila y la cobertura no disminuye

---
Close #51 