### PR TITLE
Add connection-form validation tests and non-wasm connection workflow test

### DIFF
--- a/tests/frontend/app.rs
+++ b/tests/frontend/app.rs
@@ -131,6 +131,35 @@ async fn GivenAppComponent_WhenConnectionFormIsSubmitted_ThenStatus_ShouldRender
     assert_eq!(password.type_(), "password");
 }
 
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn GivenConnectionFormValues_WhenBuiltAndConnectionIsTested_ThenWorkflow_ShouldConnectSuccessfully() {
+    let state = sql_intelliscan_ui::app::ConnectionFormState {
+        host: "localhost".to_string(),
+        port: "1433".to_string(),
+        database: "master".to_string(),
+        username: "sa".to_string(),
+        password: "StrongPassword123".to_string(),
+        encrypt: true,
+        trust_server_certificate: true,
+        connection_timeout_seconds: "30".to_string(),
+        application_name: "SQL Intelliscan Integration Test".to_string(),
+    };
+
+    let request = sql_intelliscan_ui::app::build_connection_test_request(&state)
+        .expect("form values should build a valid connection request");
+
+    let response = futures::executor::block_on(
+        sql_intelliscan_ui::services::connection_service::test_connection(request),
+    )
+    .expect("connection test should succeed with mocked tauri backend");
+
+    assert!(response.success);
+    assert_eq!(response.message, "Connection successful");
+    assert_eq!(response.database.as_deref(), Some("master"));
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn GivenName_WhenInvokeGreetSyncIsCalled_ThenResponse_ShouldContainGreeting() {

--- a/tests/frontend/connection_form.rs
+++ b/tests/frontend/connection_form.rs
@@ -8,6 +8,142 @@ fn field_names(errors: &[sql_intelliscan_ui::app::FieldValidationError]) -> Vec<
     errors.iter().map(|error| error.field).collect()
 }
 
+
+
+fn expected_message_for_selected_language(field: ConnectionFormField, selected_language: &str) -> &'static str {
+    match selected_language {
+        "en" => match field {
+            ConnectionFormField::Host => "Enter the SQL Server host.",
+            ConnectionFormField::Port => "Enter a port between 1 and 65535.",
+            ConnectionFormField::Database => "Enter the database name.",
+            ConnectionFormField::Username => "Enter the SQL Server username.",
+            ConnectionFormField::Password => "Enter the password.",
+            ConnectionFormField::ConnectionTimeout => "Enter a timeout between 1 and 300 seconds.",
+            ConnectionFormField::ApplicationName => "Enter an application name or leave it empty.",
+        },
+        _ => panic!("unsupported selected language in test suite"),
+    }
+}
+
+fn valid_state_with_required_credentials() -> ConnectionFormState {
+    ConnectionFormState {
+        username: "sa".to_string(),
+        password: "StrongPassword123".to_string(),
+        ..ConnectionFormState::default()
+    }
+}
+
+#[test]
+fn GivenInvalidFieldValuesOneByOne_WhenRequestIsBuilt_ThenValidationMessages_ShouldMatchSelectedLanguage() {
+    let selected_language = "en";
+
+    let scenarios: Vec<(ConnectionFormState, ConnectionFormField)> = vec![
+        (
+            ConnectionFormState {
+                host: "   ".to_string(),
+                ..valid_state_with_required_credentials()
+            },
+            ConnectionFormField::Host,
+        ),
+        (
+            ConnectionFormState {
+                port: "0".to_string(),
+                ..valid_state_with_required_credentials()
+            },
+            ConnectionFormField::Port,
+        ),
+        (
+            ConnectionFormState {
+                database: " ".to_string(),
+                ..valid_state_with_required_credentials()
+            },
+            ConnectionFormField::Database,
+        ),
+        (
+            ConnectionFormState {
+                username: "	".to_string(),
+                ..valid_state_with_required_credentials()
+            },
+            ConnectionFormField::Username,
+        ),
+        (
+            ConnectionFormState {
+                password: "
+".to_string(),
+                ..valid_state_with_required_credentials()
+            },
+            ConnectionFormField::Password,
+        ),
+        (
+            ConnectionFormState {
+                connection_timeout_seconds: "301".to_string(),
+                ..valid_state_with_required_credentials()
+            },
+            ConnectionFormField::ConnectionTimeout,
+        ),
+        (
+            ConnectionFormState {
+                application_name: "   ".to_string(),
+                ..valid_state_with_required_credentials()
+            },
+            ConnectionFormField::ApplicationName,
+        ),
+    ];
+
+    for (state, expected_field) in scenarios {
+        let errors = build_connection_test_request(&state).expect_err("request should be invalid");
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].field, expected_field);
+        assert_eq!(
+            errors[0].message,
+            expected_message_for_selected_language(expected_field, selected_language)
+        );
+    }
+}
+
+#[test]
+fn GivenInvalidFieldCombinations_WhenRequestIsBuilt_ThenValidationMessages_ShouldMatchSelectedLanguage() {
+    let selected_language = "en";
+
+    let combined_invalid_state = ConnectionFormState {
+        host: " ".to_string(),
+        port: "70000".to_string(),
+        database: "".to_string(),
+        username: "	".to_string(),
+        password: " ".to_string(),
+        connection_timeout_seconds: "0".to_string(),
+        application_name: "   ".to_string(),
+        ..ConnectionFormState::default()
+    };
+
+    let errors = build_connection_test_request(&combined_invalid_state)
+        .expect_err("request should be invalid");
+
+    let expected_fields = [
+        ConnectionFormField::Host,
+        ConnectionFormField::Port,
+        ConnectionFormField::Database,
+        ConnectionFormField::Username,
+        ConnectionFormField::Password,
+        ConnectionFormField::ConnectionTimeout,
+        ConnectionFormField::ApplicationName,
+    ];
+
+    assert_eq!(errors.len(), expected_fields.len());
+
+    for expected_field in expected_fields {
+        let error = errors
+            .iter()
+            .find(|error| error.field == expected_field)
+            .expect("expected validation error for each invalid field");
+
+        assert_eq!(
+            error.message,
+            expected_message_for_selected_language(expected_field, selected_language)
+        );
+    }
+}
 #[test]
 fn GivenConnectionFormState_WhenDefaultIsCreated_ThenDefaults_ShouldMatchConnectionRequest() {
     let state = ConnectionFormState::default();


### PR DESCRIPTION
### Motivation

- Add robust unit tests to verify per-field and combined validation messages for the connection form match the selected language strings.
- Ensure the end-to-end connection test workflow can be exercised in non-wasm environments against the mocked backend.

### Description

- Add `expected_message_for_selected_language` and `valid_state_with_required_credentials` helpers and two tests in `tests/frontend/connection_form.rs` to validate single-field and combined-field validation errors using `build_connection_test_request`.
- Add a non-wasm integration test `GivenConnectionFormValues_WhenBuiltAndConnectionIsTested_ThenWorkflow_ShouldConnectSuccessfully` to `tests/frontend/app.rs` which builds a `ConnectionFormState`, constructs a request with `build_connection_test_request`, invokes `connection_service::test_connection` and asserts the success response and returned database.
- Keep existing frontend tests intact and reuse `ConnectionFormState::default()` for baseline expectations.

### Testing

- Ran the updated frontend tests with `cargo test --test connection_form` and `cargo test --test app`, and both test files completed successfully.
- Ran the full test suite with `cargo test --tests`, and the new tests passed alongside existing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c250a268832092ed1bb5187f483c)