### PR TITLE
🚦 US-004.5 – Handle Loading, Success, and Error States

### DIFF
--- a/src/components/connection_test/connection_form.rs
+++ b/src/components/connection_test/connection_form.rs
@@ -162,7 +162,10 @@ fn field_error(
 
 #[cfg(not(coverage))]
 #[component]
-pub fn ConnectionForm(on_submit: Callback<ConnectionTestRequest>) -> impl IntoView {
+pub fn ConnectionForm(
+    on_submit: Callback<ConnectionTestRequest>,
+    #[prop(into)] is_loading: Signal<bool>,
+) -> impl IntoView {
     let defaults = ConnectionFormState::default();
     let (host, set_host) = signal(defaults.host);
     let (port, set_port) = signal(defaults.port);
@@ -193,6 +196,10 @@ pub fn ConnectionForm(on_submit: Callback<ConnectionTestRequest>) -> impl IntoVi
 
     let submit = move |ev: leptos::ev::SubmitEvent| {
         ev.prevent_default();
+
+        if is_loading.get_untracked() {
+            return;
+        }
 
         match build_connection_test_request(&current_state()) {
             Ok(request) => {
@@ -427,11 +434,16 @@ pub fn ConnectionForm(on_submit: Callback<ConnectionTestRequest>) -> impl IntoVi
             </div>
 
             <div class="connection-actions">
-                <button id="connection-submit" class="btn-primary" type="submit">
+                <button
+                    id="connection-submit"
+                    class="btn-primary"
+                    type="submit"
+                    disabled=move || is_loading.get()
+                >
                     <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M13 10V3L4 14h7v7l9-11h-7z"/>
                     </svg>
-                    "Test Connection"
+                    {move || if is_loading.get() { "Testing..." } else { "Test Connection" }}
                 </button>
             </div>
         </form>
@@ -440,8 +452,12 @@ pub fn ConnectionForm(on_submit: Callback<ConnectionTestRequest>) -> impl IntoVi
 
 #[cfg(coverage)]
 #[component]
-pub fn ConnectionForm(on_submit: Callback<ConnectionTestRequest>) -> impl IntoView {
+pub fn ConnectionForm(
+    on_submit: Callback<ConnectionTestRequest>,
+    #[prop(into)] is_loading: Signal<bool>,
+) -> impl IntoView {
     let _ = on_submit;
+    let _ = is_loading;
     let defaults = ConnectionFormState::default();
 
     view! {

--- a/src/components/connection_test/connection_test_view.rs
+++ b/src/components/connection_test/connection_test_view.rs
@@ -143,9 +143,15 @@ pub fn ConnectionTestView() -> impl IntoView {
     });
 
     let handle_submit = Callback::new(move |request: ConnectionTestRequest| {
+        if matches!(status.get_untracked(), ConnectionTestStatus::Loading) {
+            return;
+        }
+
         set_status.set(ConnectionTestStatus::Loading);
         spawn_connection_test(request, set_status);
     });
+
+    let is_loading = Signal::derive(move || matches!(status.get(), ConnectionTestStatus::Loading));
 
     view! {
         <div class="bg-dark">
@@ -236,7 +242,7 @@ pub fn ConnectionTestView() -> impl IntoView {
                 </div>
             </section>
 
-            <ConnectionForm on_submit=handle_submit />
+            <ConnectionForm on_submit=handle_submit is_loading=is_loading />
 
             <p id="connection-status" class="connection-status" aria-live="polite">
                 {move || connection_status_message(&status.get())}
@@ -287,7 +293,7 @@ pub fn ConnectionTestView() -> impl IntoView {
                 </button>
             </section>
 
-            <ConnectionForm on_submit=Callback::new(|_| {}) />
+            <ConnectionForm on_submit=Callback::new(|_| {}) is_loading=false />
 
             <p id="connection-status" class="connection-status" aria-live="polite"></p>
         </main>

--- a/tests/frontend/connection_form.rs
+++ b/tests/frontend/connection_form.rs
@@ -278,6 +278,8 @@ fn GivenConnectionFormSource_WhenReviewed_ThenComponent_ShouldNotUseUnsafeBounda
     assert!(!source.contains("log::"));
     assert!(!source.contains("connection_string"));
     assert!(!source.contains("connectionString"));
+    assert!(source.contains("is_loading.get_untracked()"));
+    assert!(source.contains("disabled=move || is_loading.get()"));
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -289,7 +291,7 @@ mod native_render_tests {
     #[test]
     fn GivenConnectionForm_WhenRenderedToHtml_ThenPasswordInput_ShouldBeMasked() {
         let html = view! {
-            <ConnectionForm on_submit=Callback::new(|_| {}) />
+            <ConnectionForm on_submit=Callback::new(|_| {}) is_loading=false />
         }
         .to_html();
 
@@ -341,7 +343,7 @@ mod wasm_render_tests {
             root.clone()
                 .dyn_into::<HtmlElement>()
                 .expect("test root should be an html element"),
-            || view! { <sql_intelliscan_ui::app::ConnectionForm on_submit=Callback::new(|_| {}) /> },
+            || view! { <sql_intelliscan_ui::app::ConnectionForm on_submit=Callback::new(|_| {}) is_loading=false /> },
         )
         .forget();
 
@@ -371,7 +373,7 @@ mod wasm_render_tests {
                 view! {
                     <sql_intelliscan_ui::app::ConnectionForm on_submit=Callback::new(move |request| {
                         *request_sink.lock().expect("request lock should not be poisoned") = Some(request);
-                    }) />
+                    }) is_loading=false />
                 }
             },
         )
@@ -418,5 +420,36 @@ mod wasm_render_tests {
         assert_eq!(request.database, "master");
         assert_eq!(request.username, "sa");
         assert_eq!(request.password, "StrongPassword123");
+    }
+
+    #[wasm_bindgen_test]
+    fn GivenConnectionForm_WhenLoading_ThenSubmitAction_ShouldBeDisabled() {
+        console_error_panic_hook::set_once();
+
+        let root = test_root();
+
+        mount_to(
+            root.clone()
+                .dyn_into::<HtmlElement>()
+                .expect("test root should be an html element"),
+            || {
+                view! {
+                    <sql_intelliscan_ui::app::ConnectionForm
+                        on_submit=Callback::new(|_| {})
+                        is_loading=true
+                    />
+                }
+            },
+        )
+        .forget();
+
+        let button = root
+            .query_selector("#connection-submit")
+            .expect("selector should not fail")
+            .expect("submit button should exist")
+            .dyn_into::<HtmlButtonElement>()
+            .expect("submit should be a button");
+
+        assert!(button.disabled());
     }
 }

--- a/tests/frontend/connection_test_view.rs
+++ b/tests/frontend/connection_test_view.rs
@@ -25,6 +25,8 @@ fn GivenConnectionTestViewSource_WhenReviewed_ThenServiceBoundary_ShouldBeRespec
     assert!(source.contains("ConnectionTestStatus::Loading"));
     assert!(source.contains("ConnectionTestStatus::Success"));
     assert!(source.contains("ConnectionTestStatus::Error"));
+    assert!(source.contains("status.get_untracked()"));
+    assert!(source.contains("is_loading"));
     assert!(!source.contains("invoke("));
     assert!(!source.contains("ConnectionTestRequest {"));
     assert!(!source.contains("connection_string"));


### PR DESCRIPTION
# 🚦 US-004.5 – Handle Loading, Success, and Error States

## 📝 What

Implementa el manejo de los estados de carga, éxito y error en el flujo de prueba de conexión SQL Server en el frontend Leptos, coordinado por el componente `ConnectionTestView`. El objetivo es que el usuario pueda ver claramente el estado actual de la prueba de conexión: inicial, cargando, éxito o error, y pueda reintentar la prueba después de cualquier resultado.

---

## 💡 Why

Permite a los usuarios comprender en todo momento el estado de la prueba de conexión, evitando confusión y mejorando la experiencia de usuario. Además, previene envíos duplicados y asegura que nunca se expongan credenciales sensibles en el estado de la UI, cumpliendo con los requisitos de seguridad y usabilidad definidos en la historia de usuario.

---

## 🛠️ How

- Se inicializa el estado de la prueba de conexión como `Idle` usando el modelo `ConnectionTestStatus`.
- Al enviar el formulario, el estado cambia a `Loading` antes de invocar el servicio de prueba.
- El botón de envío se deshabilita mientras el estado es `Loading`, previniendo envíos duplicados.
- Al recibir respuesta del servicio:
  - Si es exitosa, el estado cambia a `Success(ConnectionTestResult)`.
  - Si falla, el estado cambia a `Error(ConnectionTestError)`.
- El usuario puede reintentar la prueba después de éxito o error, reiniciando el ciclo.
- El estado nunca almacena la contraseña, el request completo ni la cadena de conexión.
- Se actualizan los tests para verificar el nuevo flujo y las restricciones de seguridad.
- Se asegura que el componente no invoque directamente Tauri ni almacene información sensible.

### Diagrama de flujo de estados

```mermaid
stateDiagram-v2
    [*] --> Idle
    Idle --> Loading: Submit
    Loading --> Success: Ok(ConnectionTestResult)
    Loading --> Error: Err(ConnectionTestError)
    Success --> Loading: Retry
    Error --> Loading: Retry
```

---

## 🧪 How to test

1. Inicia la aplicación y navega al formulario de prueba de conexión.
2. Verifica que el estado inicial es `Idle` y no se muestra ningún mensaje de éxito o error.
3. Ingresa datos válidos y envía el formulario:
   - El botón se deshabilita y muestra "Testing...".
   - El estado cambia a `Loading`.
4. Simula una respuesta exitosa:
   - El estado cambia a `Success` y se muestra el resultado.
   - El botón se habilita para reintentar.
5. Simula una respuesta de error:
   - El estado cambia a `Error` y se muestra el mensaje de error.
   - El botón se habilita para reintentar.
6. Repite el envío tras éxito o error y verifica que el ciclo se repite correctamente.
7. Revisa que nunca se almacene la contraseña ni el request completo en el estado.
8. Ejecuta los siguientes comandos para validar el workspace:
   - ```bash
     cargo check --workspace
     cargo fmt --check
     cargo clippy --workspace --all-targets
     ``` 
   - Ejecuta los tests frontend para asegurar la cobertura y el correcto manejo de estados.

---

## 🗂️ Files changed summary

- **src/components/connection_test/connection_form.rs**
  - Se añade la prop `is_loading` para controlar el estado del botón de envío y prevenir envíos duplicados.
  - El botón muestra "Testing..." y se deshabilita durante la carga.
  - El submit ignora eventos si está en loading.

- **src/components/connection_test/connection_test_view.rs**
  - Se maneja el estado `ConnectionTestStatus` y se deriva la señal `is_loading`.
  - Se previene el submit si ya está en loading.
  - Se pasa la prop `is_loading` al formulario.

- **tests/frontend/connection_form.rs**
  - Se actualizan los tests para verificar el nuevo flujo de loading y la deshabilitación del botón.
  - Se añade test para asegurar que el botón está deshabilitado durante loading.

- **tests/frontend/connection_test_view.rs**
  - Se actualizan los tests para verificar el uso correcto de `status.get_untracked()` y `is_loading`.

---

## ☑️ Checklist

- [x] El estado inicial es `Idle`
- [x] El estado cambia a `Loading` al enviar el formulario
- [x] El botón de envío se deshabilita durante loading
- [x] No se permiten envíos duplicados mientras está cargando
- [x] El estado cambia a `Success` tras respuesta exitosa
- [x] El estado cambia a `Error` tras respuesta fallida
- [x] Se puede reintentar tras éxito o error
- [x] El resultado anterior se reemplaza en cada intento
- [x] El estado nunca almacena contraseña, request completo ni cadena de conexión
- [x] No se invoca Tauri directamente desde el componente
- [x] `cargo fmt --check` pasa correctamente
- [x] `cargo clippy --workspace --all-targets` pasa correctamente
- [x] El workspace compila y los tests pasan

---
