### PR TITLE
🪵 Select and Configure Rust Logging Stack for Backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,6 +2391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +2677,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -4454,6 +4469,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4583,6 +4607,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4597,6 +4623,7 @@ dependencies = [
  "mssqlrust",
  "sql-intelliscan-common",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4607,6 +4634,7 @@ dependencies = [
  "futures",
  "serde",
  "sql-intelliscan-repository",
+ "tracing",
 ]
 
 [[package]]
@@ -5187,6 +5215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "throw_error"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5512,6 +5549,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5698,6 +5765,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ members = [
     "src-tauri",
 ]
 
+[workspace.dependencies]
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
 [[test]]
 name = "frontend"
 path = "tests/frontend.rs"

--- a/crates/sql-intelliscan-repository/Cargo.toml
+++ b/crates/sql-intelliscan-repository/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 sql-intelliscan-common = { path = "../sql-intelliscan-common" }
 mssqlrust = "1.0.2"
+tracing = { workspace = true }
 
 [dev-dependencies]
 futures = "0.3"

--- a/crates/sql-intelliscan-services/Cargo.toml
+++ b/crates/sql-intelliscan-services/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 sql-intelliscan-repository = { path = "../sql-intelliscan-repository" }
+tracing = { workspace = true }
 
 [dev-dependencies]
 futures = "0.3"

--- a/docs/backend-logging.md
+++ b/docs/backend-logging.md
@@ -18,10 +18,12 @@ The default filter is `info`. It can be overridden with `RUST_LOG`, for example:
 
 ```bash
 RUST_LOG=debug
-RUST_LOG=sql_intelliscan=debug,warn
+RUST_LOG=sql_intelliscan_lib::logging=debug,warn
 ```
 
-Invalid filter values fall back to `info`.
+By default, `tracing` uses the Rust module path as the event target, such as `sql_intelliscan_lib::logging::logging_config`. Use `target: "sql_intelliscan::..."` in macros when you want logs to match the stable application targets shown below.
+
+Invalid filter values fall back to `info`. If another embedded component has already installed a global subscriber, backend startup treats that as non-fatal and continues.
 
 ## Conventions
 

--- a/docs/backend-logging.md
+++ b/docs/backend-logging.md
@@ -1,0 +1,71 @@
+# Backend Logging
+
+## Decision
+
+The backend logging stack is:
+
+- `tracing` for structured log emission in `src-tauri`, `services`, and `repository`.
+- `tracing-subscriber` for the single global subscriber initialized by `src-tauri`.
+- No `tracing-appender` for this story. File logging is deferred until a requirement exists.
+
+`services` and `repository` must only emit logs with `tracing` macros. They must not initialize a global subscriber or depend on `tracing-subscriber`.
+
+## Initialization
+
+Logging is initialized once from `src-tauri` through `init_logging`.
+
+The default filter is `info`. It can be overridden with `RUST_LOG`, for example:
+
+```bash
+RUST_LOG=debug
+RUST_LOG=sql_intelliscan=debug,warn
+```
+
+Invalid filter values fall back to `info`.
+
+## Conventions
+
+Use structured fields and stable targets:
+
+```rust
+use tracing::{debug, error, info, warn};
+
+info!(target: "sql_intelliscan::startup", "Application startup completed");
+debug!(target: "sql_intelliscan::connection", host = %safe_host, port = port, "Starting connection validation");
+warn!(target: "sql_intelliscan::connection", error_code = "VALIDATION_FAILED", "Connection validation failed");
+error!(target: "sql_intelliscan::repository", error_code = "CONNECTION_FAILED", "Repository operation failed");
+```
+
+Level guidance:
+
+- `trace`: deep diagnostics, never credentials or raw payloads.
+- `debug`: developer diagnostics with non-sensitive fields.
+- `info`: normal lifecycle events.
+- `warn`: recoverable or expected failures.
+- `error`: unexpected failures.
+
+## Sensitive Data
+
+Never log passwords, full connection strings, raw credential payloads, secret environment variable values, authentication tokens, private keys, or raw request objects that contain secrets.
+
+Safe fields include operation name, layer, result category, stable error code, duration, host, port, and database when they are considered non-sensitive.
+
+Safe example:
+
+```rust
+info!(
+    target: "sql_intelliscan::connection",
+    host = %safe_host,
+    port = port,
+    database = %database,
+    "Starting SQL Server connection test"
+);
+```
+
+Unsafe examples:
+
+```rust
+debug!("Connection request: {:?}", request);
+error!("Connection failed using password: {}", password);
+info!("Connection string: {}", connection_string);
+```

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sql-intelliscan-services = { path = "../crates/sql-intelliscan-services" }
 sql-intelliscan-repository = { path = "../crates/sql-intelliscan-repository" }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,8 +22,8 @@ pub use dependency_wiring::{
     build_app_state, greet_user, shared_app_state, validate_sql_server_connection,
 };
 pub use logging::{
-    build_log_filter_from_env_value, init_logging, logging_stack_decision, DEFAULT_LOG_FILTER,
-    LOG_FILTER_ENV_VAR,
+    build_log_filter_from_env_value, init_logging, logging_stack_decision, LoggingInitError,
+    DEFAULT_LOG_FILTER, LOG_FILTER_ENV_VAR,
 };
 pub use sql_intelliscan_services::errors::ServiceError;
 pub use sql_intelliscan_services::models;
@@ -57,7 +57,9 @@ pub fn reset_run_hooks() {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    init_logging().expect("backend logging should initialize once");
+    if let Err(error) = init_logging() {
+        eprintln!("{error}");
+    }
 
     let (builder_factory, runner) = *run_hooks(DEFAULT_BUILDER_FACTORY, DEFAULT_RUNNER)
         .lock()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod commands;
 mod config;
 mod configuration;
 mod dependency_wiring;
+mod logging;
 mod state;
 
 pub use bootstrap::wiring::configured_connection_string_from_env_value;
@@ -19,6 +20,10 @@ use configuration::run_builder;
 pub use configuration::{build_app, try_build_app};
 pub use dependency_wiring::{
     build_app_state, greet_user, shared_app_state, validate_sql_server_connection,
+};
+pub use logging::{
+    build_log_filter_from_env_value, init_logging, logging_stack_decision, DEFAULT_LOG_FILTER,
+    LOG_FILTER_ENV_VAR,
 };
 pub use sql_intelliscan_services::errors::ServiceError;
 pub use sql_intelliscan_services::models;
@@ -52,6 +57,8 @@ pub fn reset_run_hooks() {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    init_logging().expect("backend logging should initialize once");
+
     let (builder_factory, runner) = *run_hooks(DEFAULT_BUILDER_FACTORY, DEFAULT_RUNNER)
         .lock()
         .expect("run hooks lock poisoned");

--- a/src-tauri/src/logging/logging_config.rs
+++ b/src-tauri/src/logging/logging_config.rs
@@ -1,0 +1,52 @@
+use std::sync::OnceLock;
+
+use tracing_subscriber::{fmt, EnvFilter};
+
+pub const DEFAULT_LOG_FILTER: &str = "info";
+pub const LOG_FILTER_ENV_VAR: &str = "RUST_LOG";
+
+static LOGGING_INIT_RESULT: OnceLock<Result<(), String>> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoggingStackDecision {
+    pub emitter: &'static str,
+    pub subscriber: &'static str,
+    pub file_appender: Option<&'static str>,
+    pub environment_variable: &'static str,
+    pub default_filter: &'static str,
+}
+
+pub fn logging_stack_decision() -> LoggingStackDecision {
+    LoggingStackDecision {
+        emitter: "tracing",
+        subscriber: "tracing-subscriber",
+        file_appender: None,
+        environment_variable: LOG_FILTER_ENV_VAR,
+        default_filter: DEFAULT_LOG_FILTER,
+    }
+}
+
+pub fn build_log_filter_from_env_value(
+    configured_filter: Result<String, std::env::VarError>,
+) -> EnvFilter {
+    configured_filter
+        .ok()
+        .and_then(|filter| EnvFilter::try_new(filter).ok())
+        .unwrap_or_else(|| EnvFilter::new(DEFAULT_LOG_FILTER))
+}
+
+pub fn init_logging() -> Result<(), String> {
+    LOGGING_INIT_RESULT
+        .get_or_init(|| {
+            let filter = build_log_filter_from_env_value(std::env::var(LOG_FILTER_ENV_VAR));
+
+            fmt()
+                .with_env_filter(filter)
+                .with_target(true)
+                .with_level(true)
+                .with_thread_ids(false)
+                .try_init()
+                .map_err(|error| format!("failed to initialize backend logging: {error}"))
+        })
+        .clone()
+}

--- a/src-tauri/src/logging/logging_config.rs
+++ b/src-tauri/src/logging/logging_config.rs
@@ -1,11 +1,14 @@
+use std::error::Error;
+use std::fmt;
 use std::sync::OnceLock;
 
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::util::{SubscriberInitExt, TryInitError};
+use tracing_subscriber::{fmt as subscriber_fmt, EnvFilter};
 
 pub const DEFAULT_LOG_FILTER: &str = "info";
 pub const LOG_FILTER_ENV_VAR: &str = "RUST_LOG";
 
-static LOGGING_INIT_RESULT: OnceLock<Result<(), String>> = OnceLock::new();
+static LOGGING_INITIALIZED: OnceLock<()> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LoggingStackDecision {
@@ -14,6 +17,29 @@ pub struct LoggingStackDecision {
     pub file_appender: Option<&'static str>,
     pub environment_variable: &'static str,
     pub default_filter: &'static str,
+}
+
+#[derive(Debug)]
+pub enum LoggingInitError {
+    Subscriber(TryInitError),
+}
+
+impl fmt::Display for LoggingInitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Subscriber(error) => {
+                write!(formatter, "failed to initialize backend logging: {error}")
+            }
+        }
+    }
+}
+
+impl Error for LoggingInitError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Subscriber(error) => Some(error),
+        }
+    }
 }
 
 pub fn logging_stack_decision() -> LoggingStackDecision {
@@ -35,18 +61,35 @@ pub fn build_log_filter_from_env_value(
         .unwrap_or_else(|| EnvFilter::new(DEFAULT_LOG_FILTER))
 }
 
-pub fn init_logging() -> Result<(), String> {
-    LOGGING_INIT_RESULT
-        .get_or_init(|| {
-            let filter = build_log_filter_from_env_value(std::env::var(LOG_FILTER_ENV_VAR));
+pub fn init_logging() -> Result<(), LoggingInitError> {
+    if LOGGING_INITIALIZED.get().is_some() {
+        return Ok(());
+    }
 
-            fmt()
-                .with_env_filter(filter)
-                .with_target(true)
-                .with_level(true)
-                .with_thread_ids(false)
-                .try_init()
-                .map_err(|error| format!("failed to initialize backend logging: {error}"))
-        })
-        .clone()
+    let filter = build_log_filter_from_env_value(std::env::var(LOG_FILTER_ENV_VAR));
+
+    match subscriber_fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_level(true)
+        .with_thread_ids(false)
+        .finish()
+        .try_init()
+    {
+        Ok(()) => {
+            let _ = LOGGING_INITIALIZED.set(());
+            Ok(())
+        }
+        Err(error) if is_global_subscriber_already_set(&error) => {
+            let _ = LOGGING_INITIALIZED.set(());
+            Ok(())
+        }
+        Err(error) => Err(LoggingInitError::Subscriber(error)),
+    }
+}
+
+fn is_global_subscriber_already_set(error: &TryInitError) -> bool {
+    error
+        .to_string()
+        .contains("global default trace dispatcher has already been set")
 }

--- a/src-tauri/src/logging/mod.rs
+++ b/src-tauri/src/logging/mod.rs
@@ -1,6 +1,6 @@
 pub mod logging_config;
 
 pub use logging_config::{
-    build_log_filter_from_env_value, init_logging, logging_stack_decision, DEFAULT_LOG_FILTER,
-    LOG_FILTER_ENV_VAR,
+    build_log_filter_from_env_value, init_logging, logging_stack_decision, LoggingInitError,
+    DEFAULT_LOG_FILTER, LOG_FILTER_ENV_VAR,
 };

--- a/src-tauri/src/logging/mod.rs
+++ b/src-tauri/src/logging/mod.rs
@@ -1,0 +1,6 @@
+pub mod logging_config;
+
+pub use logging_config::{
+    build_log_filter_from_env_value, init_logging, logging_stack_decision, DEFAULT_LOG_FILTER,
+    LOG_FILTER_ENV_VAR,
+};

--- a/tests/backend/logging_config.rs
+++ b/tests/backend/logging_config.rs
@@ -1,0 +1,47 @@
+#![allow(non_snake_case)]
+
+use std::env::VarError;
+
+use sql_intelliscan_lib::{
+    build_log_filter_from_env_value, init_logging, logging_stack_decision, DEFAULT_LOG_FILTER,
+    LOG_FILTER_ENV_VAR,
+};
+
+#[test]
+fn GivenLoggingStack_WhenDecisionIsReviewed_ThenSelection_ShouldUseTracingWithoutFileAppender() {
+    let decision = logging_stack_decision();
+
+    assert_eq!(decision.emitter, "tracing");
+    assert_eq!(decision.subscriber, "tracing-subscriber");
+    assert_eq!(decision.file_appender, None);
+    assert_eq!(decision.environment_variable, LOG_FILTER_ENV_VAR);
+    assert_eq!(decision.default_filter, DEFAULT_LOG_FILTER);
+}
+
+#[test]
+fn GivenNoLogEnvironment_WhenFilterIsBuilt_ThenDefaultLevel_ShouldBeInfo() {
+    let filter = build_log_filter_from_env_value(Err(VarError::NotPresent));
+
+    assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+}
+
+#[test]
+fn GivenConfiguredLogEnvironment_WhenFilterIsBuilt_ThenConfiguredLevel_ShouldBeUsed() {
+    let filter = build_log_filter_from_env_value(Ok("sql_intelliscan=debug,warn".to_string()));
+
+    assert_eq!(filter.to_string(), "sql_intelliscan=debug,warn");
+}
+
+#[test]
+fn GivenInvalidLogEnvironment_WhenFilterIsBuilt_ThenDefaultLevel_ShouldBeUsed() {
+    let filter =
+        build_log_filter_from_env_value(Ok("sql_intelliscan=definitely_invalid_level".to_string()));
+
+    assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+}
+
+#[test]
+fn GivenBackendStartup_WhenLoggingInitializesRepeatedly_ThenInitialization_ShouldBeIdempotent() {
+    init_logging().expect("logging should initialize");
+    init_logging().expect("logging initialization should be idempotent");
+}


### PR DESCRIPTION
# 🪵 Select and Configure Rust Logging Stack for Backend

## ❓ What

Seleccionar y configurar una pila de logging en Rust para los crates backend (`src-tauri`, `services`, `repository`), asegurando una base centralizada, estructurada y segura para la emisión de logs en la aplicación.

---

## 🤔 Why

- Proveer una solución de logging consistente y centralizada para todos los eventos, advertencias y errores del backend.
- Permitir filtrado por nivel de log y configuración vía entorno.
- Facilitar el diagnóstico seguro y evitar la exposición de datos sensibles.
- Cumplir con los criterios de aceptación de la historia US-005.1.

---

## 🛠️ How

- Se seleccionó la pila de logging recomendada: `tracing` y `tracing-subscriber`.
- Se agregaron las dependencias en el workspace y en los crates correspondientes:
  - `src-tauri`: `tracing`, `tracing-subscriber`
  - `services` y `repository`: solo `tracing`
- Se creó el módulo de configuración de logging en `src-tauri/src/logging/`:
  - `mod.rs` y `logging_config.rs`
  - Función `init_logging()` para inicializar el subscriber global.
  - Soporte para configuración de nivel de log vía variable de entorno `RUST_LOG`, con fallback seguro a `info`.
  - Exposición de constantes y helpers para la configuración y decisión de stack.
- Se documentaron las convenciones de logging y reglas de datos sensibles en `docs/backend-logging.md`.
- Se agregaron pruebas unitarias en `tests/backend/logging_config.rs` para validar la configuración, idempotencia y reglas de filtrado.
- Se actualizó la inicialización del backend para llamar a `init_logging()` una sola vez al inicio.
- Se validó que los crates inferiores no inicializan logging global ni dependen de `tracing-subscriber`.
- Se aseguraron ejemplos y documentación de buenas prácticas y restricciones de seguridad.

```mermaid
flowchart TD
    A["App Startup (src-tauri)"] -->|"init_logging()"| B[tracing-subscriber]
    B -->|Global Subscriber| C[tracing macros]
    C -->|Emit logs| D[services/repository]
    D -->|NO subscriber init| E[Centralized logs]
```

---

## 🧪 How to test

- Ejecutar los siguientes comandos para validar la integración y convenciones:
  - ```bash
    cargo check --workspace
    cargo fmt --check
    cargo clippy --workspace --all-targets
    ``` 
- Revisar que:
  - El workspace compila y pasa los chequeos de formato y lint.
  - Los tests en `tests/backend/logging_config.rs` pasan correctamente.
  - El archivo `docs/backend-logging.md` documenta la decisión, convenciones y reglas de seguridad.
  - No existen inicializaciones de `tracing-subscriber` ni `tracing-appender` en `services` o `repository`.
  - No se loguean datos sensibles (contraseñas, connection strings, etc.).
- Probar la variable de entorno:
  - Sin `RUST_LOG` → nivel por defecto `info`.
  - Con `RUST_LOG=debug` → nivel debug.
  - Con valor inválido → fallback seguro a `info`.

---

## 🗂️ Files changed summary

- **Cargo.toml**: Se agregaron dependencias de workspace para `tracing` y `tracing-subscriber`.
- **crates/sql-intelliscan-repository/Cargo.toml**: Se añadió dependencia a `tracing`.
- **crates/sql-intelliscan-services/Cargo.toml**: Se añadió dependencia a `tracing`.
- **src-tauri/Cargo.toml**: Se añadieron dependencias a `tracing` y `tracing-subscriber`.
- **src-tauri/src/lib.rs**: Se importó y llamó a la inicialización de logging.
- **src-tauri/src/logging/mod.rs** y **src-tauri/src/logging/logging_config.rs**: Nuevo módulo de configuración de logging.
- **docs/backend-logging.md**: Nueva documentación de convenciones y reglas de logging.
- **tests/backend/logging_config.rs**: Nuevas pruebas unitarias para la configuración de logging.
- **Cargo.lock**: Actualización automática de dependencias.

---

## ☑️ Checklist

- [x] Se seleccionó y documentó la pila de logging.
- [x] Se agregaron las dependencias correctas en cada crate.
- [x] Se creó el módulo de configuración de logging en `src-tauri`.
- [x] Se implementó la función `init_logging()` y helpers asociados.
- [x] Se soporta configuración de nivel de log vía entorno.
- [x] Se documentaron convenciones y reglas de datos sensibles.
- [x] Se agregaron pruebas unitarias para la configuración.
- [x] Los crates inferiores no inicializan logging global.
- [x] El workspace compila y pasa los chequeos de formato y lint.
- [x] No se loguean datos sensibles.
- [x] Se documentó la decisión de no incluir `tracing-appender` por ahora.
- [x] Se cumple con todos los criterios de aceptación de la historia de usuario.

---