### PR TITLE
🚦 Add Safe Logging to Tauri Commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,6 +4649,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "sql-intelliscan",
  "tauri",
+ "tracing",
+ "tracing-subscriber",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ csr = ["leptos/csr"]
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 futures = "0.3"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 leptos = { version = "0.8.19", features = ["ssr"] }

--- a/src-tauri/src/commands/connection_commands.rs
+++ b/src-tauri/src/commands/connection_commands.rs
@@ -1,8 +1,12 @@
-use std::fmt;
+use std::{fmt, time::Instant};
 
 use serde::Deserialize;
+use tracing::{debug, info, warn};
 
 use crate::{AppState, CommandErrorResponse, ConnectionTestResponse, ServiceError};
+
+const COMMAND_LOG_TARGET: &str = "sql_intelliscan::commands";
+const TEST_CONNECTION_COMMAND: &str = "test_connection";
 
 #[derive(Clone, PartialEq, Eq, Deserialize)]
 pub struct ConnectionTestRequest {
@@ -45,14 +49,65 @@ pub async fn test_connection_with_state(
     state: &AppState,
     request: ConnectionTestRequest,
 ) -> Result<ConnectionTestResponse, CommandErrorResponse> {
-    let connection_string = connection_string_from_request(&request)
-        .map_err(CommandErrorResponse::from_service_error)?;
+    let started_at = Instant::now();
 
-    state
+    info!(
+        target: COMMAND_LOG_TARGET,
+        command = TEST_CONNECTION_COMMAND,
+        "Tauri command started"
+    );
+
+    debug!(
+        target: COMMAND_LOG_TARGET,
+        command = TEST_CONNECTION_COMMAND,
+        port = request.port,
+        timeout_seconds = request.connection_timeout_seconds,
+        encrypt = request.encrypt,
+        trust_server_certificate = request.trust_server_certificate,
+        "Received connection test request metadata"
+    );
+
+    let connection_string = match connection_string_from_request(&request) {
+        Ok(connection_string) => connection_string,
+        Err(error) => {
+            let command_error = CommandErrorResponse::from_service_error(error);
+            warn!(
+                target: COMMAND_LOG_TARGET,
+                command = TEST_CONNECTION_COMMAND,
+                error_code = %command_error.code,
+                elapsed_ms = started_at.elapsed().as_millis(),
+                "Tauri command failed"
+            );
+            return Err(command_error);
+        }
+    };
+
+    match state
         .test_connection_with_connection_string(&connection_string)
         .await
         .map(ConnectionTestResponse::from)
         .map_err(CommandErrorResponse::from_service_error)
+    {
+        Ok(response) => {
+            info!(
+                target: COMMAND_LOG_TARGET,
+                command = TEST_CONNECTION_COMMAND,
+                elapsed_ms = started_at.elapsed().as_millis(),
+                "Tauri command completed successfully"
+            );
+            Ok(response)
+        }
+        Err(command_error) => {
+            warn!(
+                target: COMMAND_LOG_TARGET,
+                command = TEST_CONNECTION_COMMAND,
+                error_code = %command_error.code,
+                elapsed_ms = started_at.elapsed().as_millis(),
+                "Tauri command failed"
+            );
+            Err(command_error)
+        }
+    }
 }
 
 pub fn connection_string_from_request(

--- a/src-tauri/src/commands/greeting_commands.rs
+++ b/src-tauri/src/commands/greeting_commands.rs
@@ -1,10 +1,32 @@
+use std::time::Instant;
+
+use tracing::info;
+
 use crate::{state::AppState, CommandSuccessResponse};
+
+const COMMAND_LOG_TARGET: &str = "sql_intelliscan::commands";
+const GREET_COMMAND: &str = "greet_command";
 
 pub fn greet_command(
     state: tauri::State<'_, AppState>,
     name: &str,
 ) -> CommandSuccessResponse<String> {
+    let started_at = Instant::now();
+
+    info!(
+        target: COMMAND_LOG_TARGET,
+        command = GREET_COMMAND,
+        "Tauri command started"
+    );
+
     let message = greet_with_state(state.inner(), name);
+
+    info!(
+        target: COMMAND_LOG_TARGET,
+        command = GREET_COMMAND,
+        elapsed_ms = started_at.elapsed().as_millis(),
+        "Tauri command completed successfully"
+    );
 
     CommandSuccessResponse {
         message: "Greeting generated successfully".to_string(),

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use std::{
+    fmt,
     future::Future,
     pin::Pin,
     sync::{Arc, Mutex},
@@ -13,6 +14,79 @@ use sql_intelliscan_lib::{
     GreetingServicePort, ServiceError,
 };
 use tauri::Manager;
+use tracing::{
+    field::{Field, Visit},
+    Event, Subscriber,
+};
+use tracing_subscriber::{layer::Context, prelude::*, registry::LookupSpan, Layer};
+
+#[derive(Clone)]
+struct CapturedLogLayer {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+#[derive(Default)]
+struct CapturedLogVisitor {
+    fields: Vec<String>,
+}
+
+impl Visit for CapturedLogVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields.push(format!("{}={value}", field.name()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields.push(format!("{}={value}", field.name()));
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.fields.push(format!("{}={value}", field.name()));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields.push(format!("{}={value}", field.name()));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.fields.push(format!("{}={value:?}", field.name()));
+    }
+}
+
+impl<S> Layer<S> for CapturedLogLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = CapturedLogVisitor::default();
+        event.record(&mut visitor);
+
+        let mut log_entry = format!("target={}", event.metadata().target());
+        if !visitor.fields.is_empty() {
+            log_entry.push(' ');
+            log_entry.push_str(&visitor.fields.join(" "));
+        }
+
+        self.events
+            .lock()
+            .expect("captured log lock should not be poisoned")
+            .push(log_entry);
+    }
+}
+
+fn capture_logs<R>(operation: impl FnOnce() -> R) -> (R, Vec<String>) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(CapturedLogLayer {
+        events: events.clone(),
+    });
+
+    let result = tracing::subscriber::with_default(subscriber, operation);
+    let logs = events
+        .lock()
+        .expect("captured log lock should not be poisoned")
+        .clone();
+
+    (result, logs)
+}
 
 fn valid_connection_request() -> ConnectionTestRequest {
     ConnectionTestRequest {
@@ -72,6 +146,27 @@ fn GivenManagedState_WhenGreetCommandIsCalled_ThenResponse_ShouldWrapGreetingMes
 
     assert_eq!(result.message, "Greeting generated successfully");
     assert_eq!(result.data, "Hello, Ana! You've been greeted from Rust!");
+}
+
+#[test]
+fn GivenName_WhenGreetCommandRuns_ThenLogs_ShouldIncludeSafeLifecycleMetadata() {
+    let app_state = build_app_state().expect("app state should build");
+    let app = tauri::test::mock_builder()
+        .manage(app_state)
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("mock app should build");
+
+    let (result, logs) = capture_logs(|| greet_command(app.state(), "Sensitive Name"));
+
+    assert_eq!(result.message, "Greeting generated successfully");
+
+    let logs = logs.join("\n");
+    assert!(logs.contains("target=sql_intelliscan::commands"));
+    assert!(logs.contains("command=greet_command"));
+    assert!(logs.contains("message=Tauri command started"));
+    assert!(logs.contains("message=Tauri command completed successfully"));
+    assert!(logs.contains("elapsed_ms="));
+    assert!(!logs.contains("Sensitive Name"));
 }
 
 #[test]
@@ -185,6 +280,68 @@ fn GivenSuccessfulServiceResult_WhenTestConnectionCommandRuns_ThenResponse_Shoul
     assert_eq!(response.database.as_deref(), Some("master"));
     assert_eq!(response.latency_ms, Some(42));
     assert_eq!(response.server_version, None);
+}
+
+#[test]
+fn GivenConnectionRequest_WhenTestConnectionCommandSucceeds_ThenLogs_ShouldIncludeSafeLifecycleMetadata(
+) {
+    let app_state = AppState::new(
+        Arc::new(MockGreetingService),
+        Arc::new(SuccessfulConnectionService),
+    );
+
+    let (response, logs) = capture_logs(|| {
+        tauri::async_runtime::block_on(test_connection_with_state(
+            &app_state,
+            valid_connection_request(),
+        ))
+    });
+
+    response.expect("connection test should succeed");
+
+    let logs = logs.join("\n");
+    assert!(logs.contains("target=sql_intelliscan::commands"));
+    assert!(logs.contains("command=test_connection"));
+    assert!(logs.contains("message=Tauri command started"));
+    assert!(logs.contains("message=Received connection test request metadata"));
+    assert!(logs.contains("port=1433"));
+    assert!(logs.contains("timeout_seconds=30"));
+    assert!(logs.contains("encrypt=true"));
+    assert!(logs.contains("trust_server_certificate=true"));
+    assert!(logs.contains("message=Tauri command completed successfully"));
+    assert!(logs.contains("elapsed_ms="));
+    assert!(!logs.contains("StrongPassword123"));
+    assert!(!logs.contains("Password="));
+    assert!(!logs.contains("User Id="));
+    assert!(!logs.contains("Server=localhost"));
+    assert!(!logs.contains("username"));
+}
+
+#[test]
+fn GivenConnectionRequestWithSecret_WhenConnectionCommandFails_ThenLogs_ShouldIncludeOnlySafeErrorCode(
+) {
+    let app_state = AppState::new(Arc::new(MockGreetingService), Arc::new(MockConnectionService));
+
+    let (result, logs) = capture_logs(|| {
+        tauri::async_runtime::block_on(test_connection_with_state(
+            &app_state,
+            valid_connection_request(),
+        ))
+    });
+
+    let error = result.expect_err("expected service error");
+    assert_eq!(error.code, "CONNECTION_FAILED");
+
+    let logs = logs.join("\n");
+    assert!(logs.contains("command=test_connection"));
+    assert!(logs.contains("message=Tauri command failed"));
+    assert!(logs.contains("error_code=CONNECTION_FAILED"));
+    assert!(logs.contains("elapsed_ms="));
+    assert!(!logs.contains("StrongPassword123"));
+    assert!(!logs.contains("Password="));
+    assert!(!logs.contains("User Id="));
+    assert!(!logs.contains("Server=localhost"));
+    assert!(!logs.contains("SourceUnavailable"));
 }
 
 #[derive(Default)]

--- a/tests/backend/lib.rs
+++ b/tests/backend/lib.rs
@@ -158,7 +158,7 @@ fn GivenCapturedStartupState_WhenRunStartupExecutes_ThenClosures_ShouldBeAccepte
 
             Ok(())
         },
-        || tauri::Builder::default(),
+        tauri::Builder::default,
         |_builder| {
             runner_called.set(true);
         },


### PR DESCRIPTION
# 🚦 Add Safe Logging to Tauri Commands

## 📝 What

Add structured and safe logging to Tauri command handlers in the backend layer (`src-tauri/src/commands`). The goal is to log key command lifecycle events (start, success, failure, duration) without exposing sensitive data such as passwords, connection strings, or credentials.

---

## 🤔 Why

This enables developers to trace and diagnose Tauri command execution safely, making troubleshooting and monitoring easier, while ensuring that no sensitive user or connection information is exposed in logs.

---

## 🛠️ How

- Import and use `tracing` macros (`info!`, `debug!`, `warn!`) in command modules.
- Define a common logging target: `sql_intelliscan::commands`.
- Log the start of each command, including the command name.
- Log command success, including execution duration.
- Log command failure, including a safe error code and duration.
- Avoid logging full payloads, passwords, connection strings, or credentials.
- Log only safe metadata (port, timeout, security flags) for commands receiving user input.
- Ensure business logic remains delegated to services, keeping commands thin.
- Update and add unit tests to verify logs meet safety and traceability criteria.
- Add `tracing` and `tracing-subscriber` dependencies to the workspace.

---

## 🧪 How to Test

- Run backend tests:  
  ```bash
  cargo test --package sql-intelliscan --test backend
  ```
- Validate that logs generated by Tauri commands:
  - Include the command name, start, success, failure, and duration events.
  - Do not contain passwords, connection strings, credentials, or sensitive data.
  - Only include safe metadata.
- Ensure no `println!` or `dbg!` is used for operational logging.
- Confirm business logic is still delegated to services.
- Run the following commands to ensure formatting and linting:
  ```bash
  cargo check --workspace
  cargo fmt --check
  cargo clippy --workspace --all-targets
  ```

---

## 🗺️ Implementation Diagram

```mermaid
flowchart TD
    A["Leptos Frontend"] --> B["Tauri Command Handler"]
    B -->|"info! (start)"| C["Log: Command Started"]
    B --> D["Call Service Layer"]
    D -->|"Result"| E{"Success or Failure"}
    E -- "Success" --> F["info! (success)"]
    E -- "Failure" --> G["warn! (failure)"]
    F --> H["Log: Duration, Command Name"]
    G --> I["Log: Error Code, Duration"]
    H --> J["Return Safe Response"]
    I --> J
```

---

## 🗂️ Files Changed Summary

- **Cargo.toml / Cargo.lock**: Added `tracing` and `tracing-subscriber` dependencies.
- **src-tauri/src/commands/connection_commands.rs**:  
  - Added safe logging throughout the command lifecycle.
  - Avoided logging sensitive data.
- **src-tauri/src/commands/greeting_commands.rs**:  
  - Added start and success logs.
- **tests/backend/commands.rs**:  
  - Implemented a log capture layer for tests.
  - Added tests to verify safe logs and absence of sensitive data.
- **tests/backend/lib.rs**:  
  - Minor refactor for logging compatibility.

---

## ☑️ Checklist

- [x] Tauri commands emit safe logs on start, success, and failure.
- [x] Execution duration is logged where useful.
- [x] Logs include command name and, on failure, a safe error code.
- [x] No passwords, connection strings, or credentials are logged.
- [x] No full payloads or raw SQL driver errors are logged.
- [x] No `println!` or `dbg!` is used for operational logging.
- [x] Commands continue to delegate business logic to services.
- [x] Tests validate presence of safe logs and absence of sensitive data.
- [x] Workspace builds and passes formatting and lint checks.
- [x] Test coverage is maintained as per project rules.

---

close #73 