### PR TITLE
🛡️ Add Safe Logging to Repository Layer

### DIFF
--- a/crates/sql-intelliscan-repository/src/errors/repository_error.rs
+++ b/crates/sql-intelliscan-repository/src/errors/repository_error.rs
@@ -6,4 +6,22 @@ pub enum RepositoryError {
     ResultMappingFailed(&'static str),
 }
 
+impl RepositoryError {
+    pub fn safe_category(&self) -> &'static str {
+        match self {
+            Self::SourceUnavailable => "CONNECTION_FAILED",
+            Self::InvalidConfiguration(_) => "INVALID_CONFIGURATION",
+            Self::QueryExecutionFailed(message) if is_timeout_failure(message) => "TIMEOUT",
+            Self::QueryExecutionFailed(_) => "QUERY_VALIDATION_FAILED",
+            Self::ResultMappingFailed(_) => "QUERY_VALIDATION_FAILED",
+        }
+    }
+}
+
 pub type RepositoryResult<T> = Result<T, RepositoryError>;
+
+fn is_timeout_failure(message: &str) -> bool {
+    let normalized = message.to_ascii_lowercase();
+
+    normalized.contains("timeout") || normalized.contains("timed out")
+}

--- a/crates/sql-intelliscan-repository/src/errors/repository_error.rs
+++ b/crates/sql-intelliscan-repository/src/errors/repository_error.rs
@@ -7,7 +7,7 @@ pub enum RepositoryError {
 }
 
 impl RepositoryError {
-    pub fn safe_category(&self) -> &'static str {
+    pub(crate) fn safe_category(&self) -> &'static str {
         match self {
             Self::SourceUnavailable => "CONNECTION_FAILED",
             Self::InvalidConfiguration(_) => "INVALID_CONFIGURATION",
@@ -24,4 +24,35 @@ fn is_timeout_failure(message: &str) -> bool {
     let normalized = message.to_ascii_lowercase();
 
     normalized.contains("timeout") || normalized.contains("timed out")
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use super::RepositoryError;
+
+    #[test]
+    fn GivenRepositoryErrors_WhenSafeCategoryIsRequested_ThenResult_ShouldReturnDiagnosticCategories(
+    ) {
+        assert_eq!(
+            RepositoryError::InvalidConfiguration("missing password").safe_category(),
+            "INVALID_CONFIGURATION"
+        );
+        assert_eq!(
+            RepositoryError::SourceUnavailable.safe_category(),
+            "CONNECTION_FAILED"
+        );
+        assert_eq!(
+            RepositoryError::QueryExecutionFailed("connection timeout".to_owned()).safe_category(),
+            "TIMEOUT"
+        );
+        assert_eq!(
+            RepositoryError::QueryExecutionFailed("validation failed".to_owned()).safe_category(),
+            "QUERY_VALIDATION_FAILED"
+        );
+        assert_eq!(
+            RepositoryError::ResultMappingFailed("unexpected scalar type").safe_category(),
+            "QUERY_VALIDATION_FAILED"
+        );
+    }
 }

--- a/crates/sql-intelliscan-repository/src/sql_server/connection_repository.rs
+++ b/crates/sql-intelliscan-repository/src/sql_server/connection_repository.rs
@@ -1,10 +1,17 @@
+use std::time::Instant;
+
 use mssqlrust::{dataset::DataValue, execute_scalar, infrastructure::mssql::MssqlConfig, Command};
+use tracing::{debug, info, warn};
 
 use crate::{
     contracts::ConnectionRepository,
     errors::{RepositoryError, RepositoryResult},
     models::SqlServerConnectionConfig,
 };
+
+const SQL_SERVER_REPOSITORY_TARGET: &str = "sql_intelliscan::repository::sql_server";
+const CONNECTION_REPOSITORY_NAME: &str = "SqlServerConnectionRepository";
+const VALIDATE_CONNECTION_OPERATION: &str = "validate_connection";
 
 enum MssqlScalarClient {
     Default,
@@ -128,22 +135,83 @@ impl SqlServerConnectionRepository {
 
 impl ConnectionRepository for SqlServerConnectionRepository {
     async fn validate_connection(&self) -> RepositoryResult<bool> {
-        let scalar = self.execute_validation_query().await?;
+        let started_at = Instant::now();
 
-        Self::map_validation_result(scalar)
+        info!(
+            target: SQL_SERVER_REPOSITORY_TARGET,
+            repository = CONNECTION_REPOSITORY_NAME,
+            operation = VALIDATE_CONNECTION_OPERATION,
+            "Repository operation started"
+        );
+
+        debug!(
+            target: SQL_SERVER_REPOSITORY_TARGET,
+            repository = CONNECTION_REPOSITORY_NAME,
+            operation = VALIDATE_CONNECTION_OPERATION,
+            port = self.config.port,
+            encrypt = self.config.encrypt,
+            trust_server_certificate = self.config.trust_server_certificate,
+            timeout_seconds = self.config.connection_timeout_seconds,
+            "SQL Server connection metadata"
+        );
+
+        let result = async {
+            let scalar = self.execute_validation_query().await?;
+
+            Self::map_validation_result(scalar)
+        }
+        .await;
+
+        match result {
+            Ok(is_valid) => {
+                info!(
+                    target: SQL_SERVER_REPOSITORY_TARGET,
+                    repository = CONNECTION_REPOSITORY_NAME,
+                    operation = VALIDATE_CONNECTION_OPERATION,
+                    elapsed_ms = started_at.elapsed().as_millis(),
+                    "Repository operation completed successfully"
+                );
+
+                Ok(is_valid)
+            }
+            Err(error) => {
+                warn!(
+                    target: SQL_SERVER_REPOSITORY_TARGET,
+                    repository = CONNECTION_REPOSITORY_NAME,
+                    operation = VALIDATE_CONNECTION_OPERATION,
+                    error_category = error.safe_category(),
+                    elapsed_ms = started_at.elapsed().as_millis(),
+                    "Repository operation failed"
+                );
+
+                Err(error)
+            }
+        }
     }
 }
 
 #[cfg(test)]
 #[allow(non_snake_case)]
 mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::{Arc, Mutex},
+    };
+
     use mssqlrust::{dataset::DataValue, infrastructure::mssql::MssqlConfig, Command};
+    use tracing::{
+        field::{Field, Visit},
+        span::{Attributes, Id, Record},
+        Event, Level, Metadata, Subscriber,
+    };
 
     use crate::{
         contracts::ConnectionRepository, errors::RepositoryError, models::SqlServerConnectionConfig,
     };
 
-    use super::{SqlServerConnectionRepository, TestMssqlScalarClient};
+    use super::{
+        SqlServerConnectionRepository, TestMssqlScalarClient, SQL_SERVER_REPOSITORY_TARGET,
+    };
 
     struct SuccessClient;
 
@@ -191,6 +259,112 @@ mod tests {
         ) -> Result<Option<DataValue>, String> {
             Err("server returned secret connection string details".to_owned())
         }
+    }
+
+    #[derive(Clone, Debug)]
+    struct CapturedEvent {
+        target: String,
+        level: Level,
+        fields: BTreeMap<String, String>,
+    }
+
+    #[derive(Default)]
+    struct CapturingSubscriber {
+        events: Mutex<Vec<CapturedEvent>>,
+    }
+
+    impl CapturingSubscriber {
+        fn captured_events(&self) -> Vec<CapturedEvent> {
+            self.events.lock().expect("events lock").clone()
+        }
+    }
+
+    impl Subscriber for CapturingSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            let metadata = event.metadata();
+            let mut visitor = EventFieldVisitor::default();
+
+            event.record(&mut visitor);
+
+            self.events
+                .lock()
+                .expect("events lock")
+                .push(CapturedEvent {
+                    target: metadata.target().to_owned(),
+                    level: *metadata.level(),
+                    fields: visitor.fields,
+                });
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    #[derive(Default)]
+    struct EventFieldVisitor {
+        fields: BTreeMap<String, String>,
+    }
+
+    impl Visit for EventFieldVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .insert(field.name().to_owned(), format!("{value:?}"));
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .insert(field.name().to_owned(), value.to_owned());
+        }
+
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_u128(&mut self, field: &Field, value: u128) {
+            self.fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+    }
+
+    fn capture_events_while(action: impl FnOnce()) -> Vec<CapturedEvent> {
+        let subscriber = Arc::new(CapturingSubscriber::default());
+        let subscriber_ref = Arc::clone(&subscriber);
+
+        tracing::subscriber::with_default(subscriber, action);
+
+        subscriber_ref.captured_events()
+    }
+
+    fn joined_event_fields(events: &[CapturedEvent]) -> String {
+        events
+            .iter()
+            .flat_map(|event| {
+                event
+                    .fields
+                    .iter()
+                    .map(|(name, value)| format!("{name}={value}"))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     fn build_config() -> SqlServerConnectionConfig {
@@ -277,6 +451,50 @@ mod tests {
     }
 
     #[test]
+    fn GivenMockClient_WhenValidationSucceeds_ThenRepository_ShouldEmitSafeOperationalLogs() {
+        let repository = SqlServerConnectionRepository::with_client(build_config(), SuccessClient);
+
+        let events = capture_events_while(|| {
+            let result =
+                futures::executor::block_on(ConnectionRepository::validate_connection(&repository));
+
+            assert_eq!(result, Ok(true));
+        });
+        let fields = joined_event_fields(&events);
+
+        assert!(events
+            .iter()
+            .any(|event| event.target == SQL_SERVER_REPOSITORY_TARGET
+                && event.level == Level::INFO
+                && event
+                    .fields
+                    .get("message")
+                    .is_some_and(|message| message.contains("Repository operation started"))));
+        assert!(events
+            .iter()
+            .any(|event| event.target == SQL_SERVER_REPOSITORY_TARGET
+                && event.level == Level::DEBUG
+                && event.fields.get("port").is_some_and(|port| port == "1433")
+                && event
+                    .fields
+                    .get("trust_server_certificate")
+                    .is_some_and(|trust| trust == "true")));
+        assert!(events
+            .iter()
+            .any(|event| event.target == SQL_SERVER_REPOSITORY_TARGET
+                && event.level == Level::INFO
+                && event.fields.contains_key("elapsed_ms")
+                && event.fields.get("message").is_some_and(
+                    |message| message.contains("Repository operation completed successfully")
+                )));
+        assert!(fields.contains("repository=SqlServerConnectionRepository"));
+        assert!(fields.contains("operation=validate_connection"));
+        assert!(!fields.contains("secret"));
+        assert!(!fields.contains("Password=secret"));
+        assert!(!fields.contains("User Id=sa"));
+    }
+
+    #[test]
     fn GivenUnexpectedScalarType_WhenValidationIsRequested_ThenRepository_ShouldMapError() {
         let repository =
             SqlServerConnectionRepository::with_client(build_config(), InvalidTypeClient);
@@ -322,6 +540,43 @@ mod tests {
                 "SQL Server validation query failed".to_owned()
             ))
         );
+    }
+
+    #[test]
+    fn GivenDriverFailureWithSensitiveDetails_WhenValidationFails_ThenRepository_ShouldEmitSafeFailureLog(
+    ) {
+        let repository =
+            SqlServerConnectionRepository::with_client(build_config(), GenericFailingClient);
+
+        let events = capture_events_while(|| {
+            let result =
+                futures::executor::block_on(ConnectionRepository::validate_connection(&repository));
+
+            assert_eq!(
+                result,
+                Err(RepositoryError::QueryExecutionFailed(
+                    "SQL Server validation query failed".to_owned()
+                ))
+            );
+        });
+        let fields = joined_event_fields(&events);
+
+        assert!(events
+            .iter()
+            .any(|event| event.target == SQL_SERVER_REPOSITORY_TARGET
+                && event.level == Level::WARN
+                && event.fields.contains_key("elapsed_ms")
+                && event
+                    .fields
+                    .get("error_category")
+                    .is_some_and(|category| category == "QUERY_VALIDATION_FAILED")
+                && event
+                    .fields
+                    .get("message")
+                    .is_some_and(|message| message.contains("Repository operation failed"))));
+        assert!(!fields.contains("secret connection string details"));
+        assert!(!fields.contains("Password=secret"));
+        assert!(!fields.contains("User Id=sa"));
     }
 
     #[test]

--- a/crates/sql-intelliscan-repository/tests/repository.rs
+++ b/crates/sql-intelliscan-repository/tests/repository.rs
@@ -31,27 +31,3 @@ fn GivenConnectionStringWithoutCredentials_WhenParsed_ThenResult_ShouldReturnInv
         Err(RepositoryError::InvalidConfiguration("missing username"))
     );
 }
-
-#[test]
-fn GivenRepositoryErrors_WhenSafeCategoryIsRequested_ThenResult_ShouldReturnDiagnosticCategories() {
-    assert_eq!(
-        RepositoryError::InvalidConfiguration("missing password").safe_category(),
-        "INVALID_CONFIGURATION"
-    );
-    assert_eq!(
-        RepositoryError::SourceUnavailable.safe_category(),
-        "CONNECTION_FAILED"
-    );
-    assert_eq!(
-        RepositoryError::QueryExecutionFailed("connection timeout".to_owned()).safe_category(),
-        "TIMEOUT"
-    );
-    assert_eq!(
-        RepositoryError::QueryExecutionFailed("validation failed".to_owned()).safe_category(),
-        "QUERY_VALIDATION_FAILED"
-    );
-    assert_eq!(
-        RepositoryError::ResultMappingFailed("unexpected scalar type").safe_category(),
-        "QUERY_VALIDATION_FAILED"
-    );
-}

--- a/crates/sql-intelliscan-repository/tests/repository.rs
+++ b/crates/sql-intelliscan-repository/tests/repository.rs
@@ -31,3 +31,27 @@ fn GivenConnectionStringWithoutCredentials_WhenParsed_ThenResult_ShouldReturnInv
         Err(RepositoryError::InvalidConfiguration("missing username"))
     );
 }
+
+#[test]
+fn GivenRepositoryErrors_WhenSafeCategoryIsRequested_ThenResult_ShouldReturnDiagnosticCategories() {
+    assert_eq!(
+        RepositoryError::InvalidConfiguration("missing password").safe_category(),
+        "INVALID_CONFIGURATION"
+    );
+    assert_eq!(
+        RepositoryError::SourceUnavailable.safe_category(),
+        "CONNECTION_FAILED"
+    );
+    assert_eq!(
+        RepositoryError::QueryExecutionFailed("connection timeout".to_owned()).safe_category(),
+        "TIMEOUT"
+    );
+    assert_eq!(
+        RepositoryError::QueryExecutionFailed("validation failed".to_owned()).safe_category(),
+        "QUERY_VALIDATION_FAILED"
+    );
+    assert_eq!(
+        RepositoryError::ResultMappingFailed("unexpected scalar type").safe_category(),
+        "QUERY_VALIDATION_FAILED"
+    );
+}


### PR DESCRIPTION
# 🛡️ Add Safe Logging to Repository Layer

## 📝 User Story
**As a** developer  
**I want** to add safe logging to the `repository` layer  
**So that** data-access operations and SQL Server connectivity issues can be diagnosed without exposing credentials, connection strings, or sensitive database details

---

## ❓ What
Se implementa safe logging en el crate `repository` usando macros de `tracing` para registrar eventos operacionales (inicio, éxito, fallo) en operaciones de acceso a datos, asegurando que nunca se expongan credenciales, contraseñas, connection strings ni detalles sensibles en los logs.

---

## 💡 Why
Permite diagnosticar problemas técnicos de conectividad y validación en SQL Server de forma segura, facilitando el soporte y la depuración sin comprometer la seguridad ni exponer información sensible en los logs.

---

## ⚙️ How

- Se agregaron imports de `tracing::{debug, info, warn}` en los módulos relevantes del repository.
- Se loguea el inicio de cada operación de repositorio con el nombre del repositorio y la operación.
- Se loguea metadata segura de la conexión (puerto, flags de seguridad, timeout) solo en nivel `debug`.
- Se loguea el éxito de la operación con duración y metadatos relevantes.
- Se loguea el fallo de la operación usando categorías seguras (`INVALID_CONFIGURATION`, `CONNECTION_FAILED`, `TIMEOUT`, `QUERY_VALIDATION_FAILED`), nunca el error crudo del driver.
- Se asegura que nunca se logueen contraseñas, connection strings, credenciales ni objetos de configuración completos.
- Se implementa helper `safe_category()` en `RepositoryError` para mapear errores a categorías seguras.
- Se agregan pruebas unitarias para verificar que los logs emitidos no contienen información sensible y cumplen con los criterios de aceptación.
- No se inicializa el logger global ni se importa `tracing_subscriber` en el crate de repository.
- No se utiliza `println!` ni `dbg!` para logging operacional.

```mermaid
flowchart TD
    A(ConnectionService) --> B(ConnectionRepositoryContract)
    B --> C(SqlServerConnectionRepository)
    C -->|log: start| D("tracing::info")
    C -->|log: safe metadata| E("tracing::debug")
    C -->|call| F(mssqlrust)
    F -->|result| G{Success?}
    G -- Yes --> H("log: success info")
    G -- No --> I("log: failure warn, safe category")
    H --> J("return Ok")
    I --> K("return Err")
```

---

## 🧪 How to Test

1. Ejecutar los tests del repositorio:
   - ```sh
     cargo test -p sql-intelliscan-repository
   ```
2. Revisar que los logs emitidos por el repositorio:
   - Incluyen eventos de inicio, éxito y fallo con categorías seguras.
   - No contienen contraseñas, connection strings, ni credenciales.
   - Incluyen solo metadata segura (puerto, flags, timeout).
3. Validar que el repositorio no inicializa el logger global (`tracing_subscriber`).
4. Validar que no se usa `println!` ni `dbg!` para logging operacional.
5. Validar que el comportamiento y los valores de retorno del repositorio no cambian.
6. Validar que el workspace compila y pasa los checks:
   - ```sh
     cargo check --workspace
     cargo fmt --check
     cargo clippy --workspace --all-targets
   ```

---

## 🗂️ Files changed summary

- **crates/sql-intelliscan-repository/src/errors/repository_error.rs**
  - Se implementa el método `safe_category()` en `RepositoryError` para mapear errores a categorías seguras.
  - Se agrega helper para detectar timeouts en mensajes de error.
- **crates/sql-intelliscan-repository/src/sql_server/connection_repository.rs**
  - Se agregan imports de `tracing`.
  - Se agregan logs de inicio, metadata segura, éxito y fallo con categorías seguras y duración.
  - Se asegura que nunca se logueen datos sensibles.
  - Se agregan pruebas unitarias para verificar la emisión de logs seguros.
- **crates/sql-intelliscan-repository/tests/repository.rs**
  - Se agregan pruebas para verificar que `safe_category()` retorna las categorías diagnósticas correctas.

---

## ☑️ Checklist

- [x] Se usan macros de `tracing` para logging operacional en el repository
- [x] Se loguea inicio de operación con nombre de repositorio y operación
- [x] Se loguea metadata segura (sin contraseñas ni connection strings)
- [x] Se loguea éxito con duración y metadatos relevantes
- [x] Se loguea fallo con categoría segura y duración
- [x] Nunca se loguean contraseñas, connection strings ni credenciales
- [x] No se inicializa el logger global (`tracing_subscriber`) en el repository
- [x] No se usa `println!` ni `dbg!` para logging operacional
- [x] El comportamiento y valores de retorno del repository permanecen sin cambios
- [x] El workspace compila y pasa los checks (`cargo check`, `cargo fmt --check`, `cargo clippy`)
- [x] Pruebas unitarias cubren los escenarios de logging seguro

---

close #80 
