### PR TITLE
feat(logging): configure log levels per environment and enhance loggi…

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -37,10 +37,6 @@ jobs:
           librsvg2-dev \
           libsoup-3.0-dev \
           libjavascriptcoregtk-4.1-dev
-      - name: Install Tauri
-        run: cargo install create-tauri-app --locked
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2.0.0" --locked
       - name: Build tests once (without running)
         run: cargo test --workspace --no-run
       - name: Test

--- a/crates/sql-intelliscan-repository/src/sql_server/connection_repository.rs
+++ b/crates/sql-intelliscan-repository/src/sql_server/connection_repository.rs
@@ -206,12 +206,16 @@ mod tests {
     };
 
     use crate::{
-        contracts::ConnectionRepository, errors::RepositoryError, models::SqlServerConnectionConfig,
+        contracts::ConnectionRepository,
+        errors::{RepositoryError, RepositoryResult},
+        models::SqlServerConnectionConfig,
     };
 
     use super::{
         SqlServerConnectionRepository, TestMssqlScalarClient, SQL_SERVER_REPOSITORY_TARGET,
     };
+
+    static LOG_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
 
     struct SuccessClient;
 
@@ -346,12 +350,34 @@ mod tests {
     }
 
     fn capture_events_while(action: impl FnOnce()) -> Vec<CapturedEvent> {
+        let _capture_guard = LOG_CAPTURE_LOCK
+            .lock()
+            .expect("log capture lock should not be poisoned");
         let subscriber = Arc::new(CapturingSubscriber::default());
         let subscriber_ref = Arc::clone(&subscriber);
 
-        tracing::subscriber::with_default(subscriber, action);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::callsite::rebuild_interest_cache();
+            action();
+            tracing::callsite::rebuild_interest_cache();
+        });
 
         subscriber_ref.captured_events()
+    }
+
+    fn validate_connection_with_log_lock(
+        repository: &SqlServerConnectionRepository,
+    ) -> RepositoryResult<bool> {
+        let _capture_guard = LOG_CAPTURE_LOCK
+            .lock()
+            .expect("log capture lock should not be poisoned");
+
+        tracing::callsite::rebuild_interest_cache();
+        let result =
+            futures::executor::block_on(ConnectionRepository::validate_connection(repository));
+        tracing::callsite::rebuild_interest_cache();
+
+        result
     }
 
     fn joined_event_fields(events: &[CapturedEvent]) -> String {
@@ -444,8 +470,7 @@ mod tests {
     fn GivenMockClient_WhenValidationIsRequested_ThenRepository_ShouldReturnTrue() {
         let repository = SqlServerConnectionRepository::with_client(build_config(), SuccessClient);
 
-        let result =
-            futures::executor::block_on(ConnectionRepository::validate_connection(&repository));
+        let result = validate_connection_with_log_lock(&repository);
 
         assert_eq!(result, Ok(true));
     }
@@ -499,8 +524,7 @@ mod tests {
         let repository =
             SqlServerConnectionRepository::with_client(build_config(), InvalidTypeClient);
 
-        let result =
-            futures::executor::block_on(ConnectionRepository::validate_connection(&repository));
+        let result = validate_connection_with_log_lock(&repository);
 
         assert_eq!(
             result,
@@ -514,8 +538,7 @@ mod tests {
     fn GivenMssqlClientFailure_WhenValidationIsRequested_ThenRepository_ShouldMapError() {
         let repository = SqlServerConnectionRepository::with_client(build_config(), FailingClient);
 
-        let result =
-            futures::executor::block_on(ConnectionRepository::validate_connection(&repository));
+        let result = validate_connection_with_log_lock(&repository);
 
         assert_eq!(
             result,
@@ -531,8 +554,7 @@ mod tests {
         let repository =
             SqlServerConnectionRepository::with_client(build_config(), GenericFailingClient);
 
-        let result =
-            futures::executor::block_on(ConnectionRepository::validate_connection(&repository));
+        let result = validate_connection_with_log_lock(&repository);
 
         assert_eq!(
             result,

--- a/docs/backend-logging.md
+++ b/docs/backend-logging.md
@@ -46,8 +46,11 @@ SQL_INTELLISCAN_LOG_LEVEL=info
 
 By default, `tracing` uses the Rust module path as the event target, such as `sql_intelliscan_lib::logging::logging_config`. Use `target: "sql_intelliscan::..."` in macros when you want logs to match the stable application targets shown below.
 
-Invalid filter values fall back to the current environment default without
-crashing. If another embedded component has already installed a global
+Invalid filter values are ignored without crashing, and the next source in the
+precedence order is attempted. For example, an invalid `RUST_LOG` value still
+allows a valid `SQL_INTELLISCAN_LOG_LEVEL` value to be used. If all configured
+overrides are missing or invalid, logging falls back to the current environment
+default. If another embedded component has already installed a global
 subscriber, backend startup treats that as non-fatal and continues.
 
 ## Conventions

--- a/docs/backend-logging.md
+++ b/docs/backend-logging.md
@@ -14,16 +14,41 @@ The backend logging stack is:
 
 Logging is initialized once from `src-tauri` through `init_logging`.
 
-The default filter is `info`. It can be overridden with `RUST_LOG`, for example:
+Runtime environment detection is centralized in `src-tauri` and reads
+`SQL_INTELLISCAN_ENV`.
+
+Supported environments and default filters:
+
+- `development`: `debug`
+- `test`: `warn`
+- `staging`: `info`
+- `production`: `warn`
+
+If `SQL_INTELLISCAN_ENV` is missing, the app assumes `development` for local
+developer ergonomics. If it is invalid or not valid Unicode, the app falls back
+to `production`.
+
+The selected environment default can be overridden. Precedence is:
+
+1. `RUST_LOG`
+2. `SQL_INTELLISCAN_LOG_LEVEL`
+3. environment default
+
+Examples:
 
 ```bash
+SQL_INTELLISCAN_ENV=development
+SQL_INTELLISCAN_ENV=production
 RUST_LOG=debug
 RUST_LOG=sql_intelliscan_lib::logging=debug,warn
+SQL_INTELLISCAN_LOG_LEVEL=info
 ```
 
 By default, `tracing` uses the Rust module path as the event target, such as `sql_intelliscan_lib::logging::logging_config`. Use `target: "sql_intelliscan::..."` in macros when you want logs to match the stable application targets shown below.
 
-Invalid filter values fall back to `info`. If another embedded component has already installed a global subscriber, backend startup treats that as non-fatal and continues.
+Invalid filter values fall back to the current environment default without
+crashing. If another embedded component has already installed a global
+subscriber, backend startup treats that as non-fatal and continues.
 
 ## Conventions
 

--- a/src-tauri/src/config/environment.rs
+++ b/src-tauri/src/config/environment.rs
@@ -1,0 +1,48 @@
+use std::env::VarError;
+
+pub const APP_ENVIRONMENT_ENV_VAR: &str = "SQL_INTELLISCAN_ENV";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppEnvironment {
+    Development,
+    Test,
+    Staging,
+    Production,
+}
+
+impl AppEnvironment {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Development => "development",
+            Self::Test => "test",
+            Self::Staging => "staging",
+            Self::Production => "production",
+        }
+    }
+}
+
+pub fn app_environment_from_env_value(
+    configured_environment: Result<String, VarError>,
+) -> AppEnvironment {
+    match configured_environment {
+        Ok(environment) => {
+            parse_app_environment(&environment).unwrap_or(AppEnvironment::Production)
+        }
+        Err(VarError::NotPresent) => AppEnvironment::Development,
+        Err(VarError::NotUnicode(_)) => AppEnvironment::Production,
+    }
+}
+
+pub fn current_app_environment() -> AppEnvironment {
+    app_environment_from_env_value(std::env::var(APP_ENVIRONMENT_ENV_VAR))
+}
+
+pub fn parse_app_environment(environment: &str) -> Option<AppEnvironment> {
+    match environment.trim().to_ascii_lowercase().as_str() {
+        "development" | "dev" => Some(AppEnvironment::Development),
+        "test" | "testing" => Some(AppEnvironment::Test),
+        "staging" | "stage" => Some(AppEnvironment::Staging),
+        "production" | "prod" => Some(AppEnvironment::Production),
+        _ => None,
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,1 +1,2 @@
 pub mod connection_config_loader;
+pub mod environment;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,14 +16,20 @@ pub use config::connection_config_loader::{
     load_connection_config, load_connection_config_from_connection_string,
     load_connection_config_from_env_value, CONNECTION_STRING_ENV_VAR,
 };
+pub use config::environment::{
+    app_environment_from_env_value, current_app_environment, parse_app_environment, AppEnvironment,
+    APP_ENVIRONMENT_ENV_VAR,
+};
 use configuration::run_builder;
 pub use configuration::{build_app, try_build_app};
 pub use dependency_wiring::{
     build_app_state, greet_user, shared_app_state, validate_sql_server_connection,
 };
 pub use logging::{
-    build_log_filter_from_env_value, init_logging, logging_stack_decision, LoggingInitError,
-    DEFAULT_LOG_FILTER, LOG_FILTER_ENV_VAR,
+    build_log_filter, build_log_filter_from_env_value,
+    build_log_filter_from_env_value_for_environment, default_log_filter_for_environment,
+    init_logging, logging_stack_decision, LoggingInitError, DEFAULT_LOG_FILTER, LOG_FILTER_ENV_VAR,
+    PROJECT_LOG_FILTER_ENV_VAR,
 };
 pub use sql_intelliscan_services::errors::ServiceError;
 pub use sql_intelliscan_services::models;

--- a/src-tauri/src/logging/logging_config.rs
+++ b/src-tauri/src/logging/logging_config.rs
@@ -5,8 +5,13 @@ use std::sync::OnceLock;
 use tracing_subscriber::util::{SubscriberInitExt, TryInitError};
 use tracing_subscriber::{fmt as subscriber_fmt, EnvFilter};
 
-pub const DEFAULT_LOG_FILTER: &str = "info";
+use crate::config::environment::{
+    current_app_environment, AppEnvironment, APP_ENVIRONMENT_ENV_VAR,
+};
+
+pub const DEFAULT_LOG_FILTER: &str = "debug";
 pub const LOG_FILTER_ENV_VAR: &str = "RUST_LOG";
+pub const PROJECT_LOG_FILTER_ENV_VAR: &str = "SQL_INTELLISCAN_LOG_LEVEL";
 
 static LOGGING_INITIALIZED: OnceLock<()> = OnceLock::new();
 
@@ -16,6 +21,8 @@ pub struct LoggingStackDecision {
     pub subscriber: &'static str,
     pub file_appender: Option<&'static str>,
     pub environment_variable: &'static str,
+    pub project_environment_variable: &'static str,
+    pub runtime_environment_variable: &'static str,
     pub default_filter: &'static str,
 }
 
@@ -48,17 +55,53 @@ pub fn logging_stack_decision() -> LoggingStackDecision {
         subscriber: "tracing-subscriber",
         file_appender: None,
         environment_variable: LOG_FILTER_ENV_VAR,
+        project_environment_variable: PROJECT_LOG_FILTER_ENV_VAR,
+        runtime_environment_variable: APP_ENVIRONMENT_ENV_VAR,
         default_filter: DEFAULT_LOG_FILTER,
+    }
+}
+
+pub fn default_log_filter_for_environment(environment: AppEnvironment) -> &'static str {
+    match environment {
+        AppEnvironment::Development => "debug",
+        AppEnvironment::Test => "warn",
+        AppEnvironment::Staging => "info",
+        AppEnvironment::Production => "warn",
     }
 }
 
 pub fn build_log_filter_from_env_value(
     configured_filter: Result<String, std::env::VarError>,
 ) -> EnvFilter {
+    build_log_filter_from_env_value_for_environment(configured_filter, AppEnvironment::Development)
+}
+
+pub fn build_log_filter_from_env_value_for_environment(
+    configured_filter: Result<String, std::env::VarError>,
+    environment: AppEnvironment,
+) -> EnvFilter {
     configured_filter
         .ok()
         .and_then(|filter| EnvFilter::try_new(filter).ok())
-        .unwrap_or_else(|| EnvFilter::new(DEFAULT_LOG_FILTER))
+        .unwrap_or_else(|| EnvFilter::new(default_log_filter_for_environment(environment)))
+}
+
+pub fn build_log_filter(
+    rust_log_filter: Result<String, std::env::VarError>,
+    project_log_filter: Result<String, std::env::VarError>,
+    environment: AppEnvironment,
+) -> EnvFilter {
+    let default_filter = default_log_filter_for_environment(environment);
+
+    rust_log_filter
+        .ok()
+        .and_then(|filter| EnvFilter::try_new(filter).ok())
+        .or_else(|| {
+            project_log_filter
+                .ok()
+                .and_then(|filter| EnvFilter::try_new(filter).ok())
+        })
+        .unwrap_or_else(|| EnvFilter::new(default_filter))
 }
 
 pub fn init_logging() -> Result<(), LoggingInitError> {
@@ -66,7 +109,11 @@ pub fn init_logging() -> Result<(), LoggingInitError> {
         return Ok(());
     }
 
-    let filter = build_log_filter_from_env_value(std::env::var(LOG_FILTER_ENV_VAR));
+    let filter = build_log_filter(
+        std::env::var(LOG_FILTER_ENV_VAR),
+        std::env::var(PROJECT_LOG_FILTER_ENV_VAR),
+        current_app_environment(),
+    );
 
     match subscriber_fmt()
         .with_env_filter(filter)

--- a/src-tauri/src/logging/logging_config.rs
+++ b/src-tauri/src/logging/logging_config.rs
@@ -12,6 +12,12 @@ use crate::config::environment::{
 pub const DEFAULT_LOG_FILTER: &str = "debug";
 pub const LOG_FILTER_ENV_VAR: &str = "RUST_LOG";
 pub const PROJECT_LOG_FILTER_ENV_VAR: &str = "SQL_INTELLISCAN_LOG_LEVEL";
+pub const ENVIRONMENT_DEFAULT_LOG_FILTERS: &[(AppEnvironment, &str)] = &[
+    (AppEnvironment::Development, "debug"),
+    (AppEnvironment::Test, "warn"),
+    (AppEnvironment::Staging, "info"),
+    (AppEnvironment::Production, "warn"),
+];
 
 static LOGGING_INITIALIZED: OnceLock<()> = OnceLock::new();
 
@@ -23,7 +29,7 @@ pub struct LoggingStackDecision {
     pub environment_variable: &'static str,
     pub project_environment_variable: &'static str,
     pub runtime_environment_variable: &'static str,
-    pub default_filter: &'static str,
+    pub environment_default_filters: &'static [(AppEnvironment, &'static str)],
 }
 
 #[derive(Debug)]
@@ -57,17 +63,17 @@ pub fn logging_stack_decision() -> LoggingStackDecision {
         environment_variable: LOG_FILTER_ENV_VAR,
         project_environment_variable: PROJECT_LOG_FILTER_ENV_VAR,
         runtime_environment_variable: APP_ENVIRONMENT_ENV_VAR,
-        default_filter: DEFAULT_LOG_FILTER,
+        environment_default_filters: ENVIRONMENT_DEFAULT_LOG_FILTERS,
     }
 }
 
 pub fn default_log_filter_for_environment(environment: AppEnvironment) -> &'static str {
-    match environment {
-        AppEnvironment::Development => "debug",
-        AppEnvironment::Test => "warn",
-        AppEnvironment::Staging => "info",
-        AppEnvironment::Production => "warn",
-    }
+    ENVIRONMENT_DEFAULT_LOG_FILTERS
+        .iter()
+        .find_map(|(configured_environment, filter)| {
+            (*configured_environment == environment).then_some(*filter)
+        })
+        .expect("every supported application environment must have a default log filter")
 }
 
 pub fn build_log_filter_from_env_value(

--- a/src-tauri/src/logging/mod.rs
+++ b/src-tauri/src/logging/mod.rs
@@ -1,6 +1,8 @@
 pub mod logging_config;
 
 pub use logging_config::{
-    build_log_filter_from_env_value, init_logging, logging_stack_decision, LoggingInitError,
-    DEFAULT_LOG_FILTER, LOG_FILTER_ENV_VAR,
+    build_log_filter, build_log_filter_from_env_value,
+    build_log_filter_from_env_value_for_environment, default_log_filter_for_environment,
+    init_logging, logging_stack_decision, LoggingInitError, DEFAULT_LOG_FILTER, LOG_FILTER_ENV_VAR,
+    PROJECT_LOG_FILTER_ENV_VAR,
 };

--- a/tests/backend/commands.rs
+++ b/tests/backend/commands.rs
@@ -20,6 +20,8 @@ use tracing::{
 };
 use tracing_subscriber::{layer::Context, prelude::*, registry::LookupSpan, Layer};
 
+static LOG_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
 #[derive(Clone)]
 struct CapturedLogLayer {
     events: Arc<Mutex<Vec<String>>>,
@@ -74,18 +76,38 @@ where
 }
 
 fn capture_logs<R>(operation: impl FnOnce() -> R) -> (R, Vec<String>) {
+    let _capture_guard = LOG_CAPTURE_LOCK
+        .lock()
+        .expect("log capture lock should not be poisoned");
     let events = Arc::new(Mutex::new(Vec::new()));
     let subscriber = tracing_subscriber::registry().with(CapturedLogLayer {
         events: events.clone(),
     });
 
-    let result = tracing::subscriber::with_default(subscriber, operation);
+    let result = tracing::subscriber::with_default(subscriber, || {
+        tracing::callsite::rebuild_interest_cache();
+        let result = operation();
+        tracing::callsite::rebuild_interest_cache();
+        result
+    });
     let logs = events
         .lock()
         .expect("captured log lock should not be poisoned")
         .clone();
 
     (result, logs)
+}
+
+fn run_with_log_callsite_lock<R>(operation: impl FnOnce() -> R) -> R {
+    let _capture_guard = LOG_CAPTURE_LOCK
+        .lock()
+        .expect("log capture lock should not be poisoned");
+
+    tracing::callsite::rebuild_interest_cache();
+    let result = operation();
+    tracing::callsite::rebuild_interest_cache();
+
+    result
 }
 
 fn valid_connection_request() -> ConnectionTestRequest {
@@ -124,7 +146,9 @@ fn GivenMissingConfiguration_WhenTestConnectionHandlerIsCalled_ThenResult_Should
     let mut request = valid_connection_request();
     request.username.clear();
 
-    let result = tauri::async_runtime::block_on(test_connection_with_state(&app_state, request));
+    let result = run_with_log_callsite_lock(|| {
+        tauri::async_runtime::block_on(test_connection_with_state(&app_state, request))
+    });
 
     let error = result.expect_err("expected invalid configuration error");
     assert_eq!(error.code, "INVALID_CONFIGURATION");
@@ -142,7 +166,7 @@ fn GivenManagedState_WhenGreetCommandIsCalled_ThenResponse_ShouldWrapGreetingMes
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .expect("mock app should build");
 
-    let result = greet_command(app.state(), "Ana");
+    let result = run_with_log_callsite_lock(|| greet_command(app.state(), "Ana"));
 
     assert_eq!(result.message, "Greeting generated successfully");
     assert_eq!(result.data, "Hello, Ana! You've been greeted from Rust!");
@@ -181,7 +205,8 @@ fn GivenManagedStateAndMissingConfiguration_WhenTestConnectionIsCalled_ThenRespo
     let mut request = valid_connection_request();
     request.password = "invalid;password".to_string();
 
-    let result = tauri::async_runtime::block_on(test_connection(app.state(), request));
+    let result =
+        run_with_log_callsite_lock(|| tauri::async_runtime::block_on(test_connection(app.state(), request)));
 
     let error = result.expect_err("expected invalid configuration error");
     assert_eq!(error.code, "INVALID_CONFIGURATION");
@@ -223,7 +248,9 @@ fn GivenMockedServices_WhenTestConnectionCommandRuns_ThenCommand_ShouldDelegateA
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .expect("mock app should build");
 
-    let result = tauri::async_runtime::block_on(test_connection(app.state(), valid_connection_request()));
+    let result = run_with_log_callsite_lock(|| {
+        tauri::async_runtime::block_on(test_connection(app.state(), valid_connection_request()))
+    });
 
     let error = result.expect_err("expected service error");
     assert_eq!(error.code, "CONNECTION_FAILED");
@@ -271,9 +298,10 @@ fn GivenSuccessfulServiceResult_WhenTestConnectionCommandRuns_ThenResponse_Shoul
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .expect("mock app should build");
 
-    let response: ConnectionTestResponse =
+    let response: ConnectionTestResponse = run_with_log_callsite_lock(|| {
         tauri::async_runtime::block_on(test_connection(app.state(), valid_connection_request()))
-            .expect("connection test should succeed");
+    })
+    .expect("connection test should succeed");
 
     assert!(response.success);
     assert_eq!(response.message, "Connection successful");
@@ -383,8 +411,10 @@ fn GivenConnectionRequest_WhenTestConnectionCommandRuns_ThenCommand_ShouldUseReq
     request.database = "inventory".to_string();
     request.encrypt = false;
 
-    let result = tauri::async_runtime::block_on(test_connection_with_state(&app_state, request))
-        .expect("connection test should succeed");
+    let result = run_with_log_callsite_lock(|| {
+        tauri::async_runtime::block_on(test_connection_with_state(&app_state, request))
+    })
+    .expect("connection test should succeed");
 
     assert_eq!(result.database.as_deref(), Some("inventory"));
     assert_eq!(result.latency_ms, Some(7));

--- a/tests/backend/environment.rs
+++ b/tests/backend/environment.rs
@@ -1,0 +1,46 @@
+#![allow(non_snake_case)]
+
+use std::{env::VarError, ffi::OsString};
+
+use sql_intelliscan_lib::{
+    app_environment_from_env_value, parse_app_environment, AppEnvironment,
+    APP_ENVIRONMENT_ENV_VAR,
+};
+
+#[test]
+fn GivenSupportedEnvironmentNames_WhenParsed_ThenEnvironment_ShouldBeResolved() {
+    assert_eq!(
+        parse_app_environment("development"),
+        Some(AppEnvironment::Development)
+    );
+    assert_eq!(parse_app_environment("TEST"), Some(AppEnvironment::Test));
+    assert_eq!(parse_app_environment("stage"), Some(AppEnvironment::Staging));
+    assert_eq!(
+        parse_app_environment("prod"),
+        Some(AppEnvironment::Production)
+    );
+}
+
+#[test]
+fn GivenMissingEnvironmentValue_WhenEnvironmentIsResolved_ThenDefault_ShouldBeDevelopment() {
+    let environment = app_environment_from_env_value(Err(VarError::NotPresent));
+
+    assert_eq!(environment, AppEnvironment::Development);
+    assert_eq!(environment.as_str(), "development");
+    assert_eq!(APP_ENVIRONMENT_ENV_VAR, "SQL_INTELLISCAN_ENV");
+}
+
+#[test]
+fn GivenInvalidEnvironmentValue_WhenEnvironmentIsResolved_ThenFallback_ShouldBeProduction() {
+    let environment = app_environment_from_env_value(Ok("unknown".to_owned()));
+
+    assert_eq!(environment, AppEnvironment::Production);
+}
+
+#[test]
+fn GivenNonUnicodeEnvironmentValue_WhenEnvironmentIsResolved_ThenFallback_ShouldBeProduction() {
+    let environment =
+        app_environment_from_env_value(Err(VarError::NotUnicode(OsString::from("invalid"))));
+
+    assert_eq!(environment, AppEnvironment::Production);
+}

--- a/tests/backend/logging_config.rs
+++ b/tests/backend/logging_config.rs
@@ -3,8 +3,9 @@
 use std::env::VarError;
 
 use sql_intelliscan_lib::{
-    build_log_filter_from_env_value, init_logging, logging_stack_decision, DEFAULT_LOG_FILTER,
-    LOG_FILTER_ENV_VAR,
+    build_log_filter, build_log_filter_from_env_value, build_log_filter_from_env_value_for_environment,
+    default_log_filter_for_environment, init_logging, logging_stack_decision, AppEnvironment,
+    DEFAULT_LOG_FILTER, LOG_FILTER_ENV_VAR, PROJECT_LOG_FILTER_ENV_VAR,
 };
 
 #[test]
@@ -15,11 +16,16 @@ fn GivenLoggingStack_WhenDecisionIsReviewed_ThenSelection_ShouldUseTracingWithou
     assert_eq!(decision.subscriber, "tracing-subscriber");
     assert_eq!(decision.file_appender, None);
     assert_eq!(decision.environment_variable, LOG_FILTER_ENV_VAR);
+    assert_eq!(decision.project_environment_variable, PROJECT_LOG_FILTER_ENV_VAR);
+    assert_eq!(
+        decision.runtime_environment_variable,
+        sql_intelliscan_lib::APP_ENVIRONMENT_ENV_VAR
+    );
     assert_eq!(decision.default_filter, DEFAULT_LOG_FILTER);
 }
 
 #[test]
-fn GivenNoLogEnvironment_WhenFilterIsBuilt_ThenDefaultLevel_ShouldBeInfo() {
+fn GivenNoLogEnvironment_WhenFilterIsBuilt_ThenDefaultLevel_ShouldBeDevelopmentDebug() {
     let filter = build_log_filter_from_env_value(Err(VarError::NotPresent));
 
     assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
@@ -33,11 +39,63 @@ fn GivenConfiguredLogEnvironment_WhenFilterIsBuilt_ThenConfiguredLevel_ShouldBeU
 }
 
 #[test]
-fn GivenInvalidLogEnvironment_WhenFilterIsBuilt_ThenDefaultLevel_ShouldBeUsed() {
-    let filter =
-        build_log_filter_from_env_value(Ok("sql_intelliscan=definitely_invalid_level".to_string()));
+fn GivenInvalidLogEnvironment_WhenFilterIsBuilt_ThenEnvironmentDefault_ShouldBeUsed() {
+    let filter = build_log_filter_from_env_value_for_environment(
+        Ok("sql_intelliscan=definitely_invalid_level".to_string()),
+        AppEnvironment::Production,
+    );
 
-    assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+    assert_eq!(filter.to_string(), "warn");
+}
+
+#[test]
+fn GivenRuntimeEnvironments_WhenDefaultFilterIsRequested_ThenLevel_ShouldMatchEnvironmentPolicy() {
+    assert_eq!(
+        default_log_filter_for_environment(AppEnvironment::Development),
+        "debug"
+    );
+    assert_eq!(default_log_filter_for_environment(AppEnvironment::Test), "warn");
+    assert_eq!(
+        default_log_filter_for_environment(AppEnvironment::Staging),
+        "info"
+    );
+    assert_eq!(
+        default_log_filter_for_environment(AppEnvironment::Production),
+        "warn"
+    );
+}
+
+#[test]
+fn GivenRustLogOverride_WhenFilterIsBuilt_ThenRustLog_ShouldTakePrecedence() {
+    let filter = build_log_filter(
+        Ok("sql_intelliscan=trace,warn".to_owned()),
+        Ok("info".to_owned()),
+        AppEnvironment::Production,
+    );
+
+    assert_eq!(filter.to_string(), "sql_intelliscan=trace,warn");
+}
+
+#[test]
+fn GivenProjectLogOverride_WhenRustLogIsMissing_ThenProjectLog_ShouldBeUsed() {
+    let filter = build_log_filter(
+        Err(VarError::NotPresent),
+        Ok("sql_intelliscan_lib=info,warn".to_owned()),
+        AppEnvironment::Production,
+    );
+
+    assert_eq!(filter.to_string(), "sql_intelliscan_lib=info,warn");
+}
+
+#[test]
+fn GivenInvalidOverrides_WhenFilterIsBuilt_ThenEnvironmentDefault_ShouldBeUsed() {
+    let filter = build_log_filter(
+        Ok("bad=definitely_invalid".to_owned()),
+        Ok("also=definitely_invalid".to_owned()),
+        AppEnvironment::Test,
+    );
+
+    assert_eq!(filter.to_string(), "warn");
 }
 
 #[test]

--- a/tests/backend/logging_config.rs
+++ b/tests/backend/logging_config.rs
@@ -21,7 +21,15 @@ fn GivenLoggingStack_WhenDecisionIsReviewed_ThenSelection_ShouldUseTracingWithou
         decision.runtime_environment_variable,
         sql_intelliscan_lib::APP_ENVIRONMENT_ENV_VAR
     );
-    assert_eq!(decision.default_filter, DEFAULT_LOG_FILTER);
+    assert_eq!(
+        decision.environment_default_filters,
+        &[
+            (AppEnvironment::Development, "debug"),
+            (AppEnvironment::Test, "warn"),
+            (AppEnvironment::Staging, "info"),
+            (AppEnvironment::Production, "warn"),
+        ]
+    );
 }
 
 #[test]
@@ -96,6 +104,17 @@ fn GivenInvalidOverrides_WhenFilterIsBuilt_ThenEnvironmentDefault_ShouldBeUsed()
     );
 
     assert_eq!(filter.to_string(), "warn");
+}
+
+#[test]
+fn GivenInvalidRustLogAndValidProjectOverride_WhenFilterIsBuilt_ThenProjectOverride_ShouldBeUsed() {
+    let filter = build_log_filter(
+        Ok("bad=definitely_invalid".to_owned()),
+        Ok("info".to_owned()),
+        AppEnvironment::Production,
+    );
+
+    assert_eq!(filter.to_string(), "info");
 }
 
 #[test]


### PR DESCRIPTION
# 🪵 Configure Log Levels per Environment

---

## 📝 What?  
🧩 **User Story:**  
Implement environment-based log level configuration for the Rust + Tauri backend, allowing different logging verbosity for development, test, staging, and production environments. Centralize configuration in `tauri-src` so that all backend crates (`tauri-src`, `services`, `repository`) respect the same log level policy, with support for environment variable overrides and safe fallbacks.

---

## 🤔 Why?  
🔍 **Motivation:**  
- Developers need detailed logs during development for diagnostics.
- Production must avoid verbose or sensitive logs for safety and performance.
- Centralized configuration prevents misconfiguration and ensures consistency.
- Environment variable overrides provide flexibility for deployment and debugging.

---

## 🛠️ How?  
🛤 **Implementation Steps:**  
- Define an `AppEnvironment` enum for supported environments (`development`, `test`, `staging`, `production`).
- Centralize environment detection in `src-tauri/src/config/environment.rs`, reading from `SQL_INTELLISCAN_ENV` with safe fallbacks.
- Define default log levels per environment:
  - development: debug
  - test: warn
  - staging: info
  - production: warn
- Support log level override via `RUST_LOG` and `SQL_INTELLISCAN_LOG_LEVEL` (with documented precedence).
- Build a `tracing_subscriber::EnvFilter` using the selected log level, falling back safely on invalid values.
- Update logging initialization to use the computed filter and ensure it is only initialized once.
- Ensure lower crates (`services`, `repository`) do not configure their own log filters.
- Add and update documentation in `docs/backend-logging.md`.
- Add backend tests for environment and logging config logic.
- Ensure sensitive data is never logged, regardless of log level.

---

## 🧪 How to Test?  
🧬 **Validation Scenarios:**  
- Set `SQL_INTELLISCAN_ENV` to each supported value and verify the default log level.
- Set `RUST_LOG` and/or `SQL_INTELLISCAN_LOG_LEVEL` and verify override precedence.
- Provide invalid values and confirm safe fallback to environment default.
- Run backend tests:  
  - ```bash
    cargo test --workspace
  - ```  
- Run static checks:  
  - ```bash
    cargo check --workspace
    cargo fmt --check
    cargo clippy --workspace --all-targets
  - ```
- Review logs to ensure no sensitive data is emitted at any level.
- Confirm that only `tauri-src` initializes the log filter.

---

## 🗺️ Architecture Diagram  
```mermaid
flowchart TD
    A[Application Startup] --> B[Read SQL_INTELLISCAN_ENV]
    B --> C{Valid Environment?}
    C -- Yes --> D[Select Default Log Level]
    C -- No --> E[Fallback to Safe Default]
    D & E --> F{Override?}
    F -- RUST_LOG --> G[Use RUST_LOG Value]
    F -- SQL_INTELLISCAN_LOG_LEVEL --> H[Use Project Log Level]
    F -- None --> I[Use Environment Default]
    G & H & I --> J[Build EnvFilter]
    J --> K[Initialize tracing_subscriber]
    K --> L[All Backend Crates Use Centralized Filter]
```

---

## 🗂️ Files changed summary

- **docs/backend-logging.md**: Documented environment-based log level configuration, supported variables, defaults, and override precedence.
- **src-tauri/src/config/environment.rs**: New module for environment detection and modeling.
- **src-tauri/src/config/mod.rs**: Exported new environment module.
- **src-tauri/src/lib.rs**: Re-exported environment and logging config APIs.
- **src-tauri/src/logging/logging_config.rs**: Refactored to support environment-based log levels, override precedence, and safe fallbacks.
- **src-tauri/src/logging/mod.rs**: Updated exports for new logging config functions.
- **tests/backend/environment.rs**: New tests for environment detection and parsing.
- **tests/backend/logging_config.rs**: Expanded tests for log filter logic, override precedence, and environment defaults.

---

## ☑️ Checklist

- [x] Runtime environment model exists
- [x] Runtime environment can be read from configuration or environment variable
- [x] Default log level exists per environment
- [x] `RUST_LOG` override is supported
- [x] Optional `SQL_INTELLISCAN_LOG_LEVEL` override is supported
- [x] Invalid log level falls back safely
- [x] `EnvFilter` is built from configuration
- [x] Log filter is applied during logging initialization
- [x] Log filtering applies across backend crates
- [x] Lower crates do not configure their own filters
- [x] Log level usage is documented
- [x] Sensitive data remains protected at all log levels
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets` passes
- [x] Workspace builds successfully

---

close #82 